### PR TITLE
fix: install script binary name mismatch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,6 +85,7 @@ if ! curl -sSfL "$DOWNLOAD_URL" -o "${TEMP_DIR}/pruner.tar.gz"; then
     fi
 else
     tar -xzf "${TEMP_DIR}/pruner.tar.gz" -C "$TEMP_DIR"
+    mv "${TEMP_DIR}/${BINARY_NAME}" "${TEMP_DIR}/pruner" 2>/dev/null || true
 fi
 
 # Install binary


### PR DESCRIPTION
## Summary
- Tarball contains `pruner-{os}-{arch}` but install script expected `pruner` after extraction
- Added `mv` to rename the extracted binary before copying to install dir

## Test plan
- [ ] `curl -sSf .../install.sh | sh` completes successfully
- [ ] Binary is installed to `~/.local/bin/pruner` and runs