### PR TITLE
docs: use bash for curl installer examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Works with **Claude Code** (recommended, via prompt-submit hook), **Codex**, **C
 ### Quick install (pre-built binary)
 
 ```bash
-curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.sh | sh
+curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.sh | bash
 ```
 
 This downloads the latest release binary for your platform (macOS/Linux, x86_64/arm64) and installs it to `~/.local/bin/`.

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 # Pruner installer — downloads pre-built binary and sets up project integration.
 #
 # Usage:
-#   curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.sh | sh
-#   curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.sh | sh -s -- --hook
+#   curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.sh | bash
+#   curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.sh | bash -s -- --hook
 #
 # Options (pass after --):
 #   --hook      Install Claude Code prompt-submit hook (better performance)


### PR DESCRIPTION
## Summary
- update installer examples to pipe `install.sh` to `bash` instead of `sh`
- keep README and script header examples aligned

## Why
The installer script uses `set -euo pipefail`, which is a bash feature. Running the published one-liner through plain `sh` fails on systems where `sh` is not bash.

## Validation
- verified the `sh` form fails with `Illegal option -o pipefail`
- verified the `bash` form installs successfully
