### PR TITLE
docs: fix remaining installer bash examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.s
 curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.sh | sh -s -- --dir /usr/local/bin
 
 # Install a specific version
-curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.sh | sh -s -- --version v0.1.0
+curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.sh | bash -s -- --version v0.1.0
 ```
 
 ### Build from source


### PR DESCRIPTION
## Summary
- replace the remaining pruner installer examples that still pipe `install.sh` to `sh`
- keep the README consistent with the script's bash requirement

## Why
The pruner installer uses `set -euo pipefail`, so the piped install examples should use `bash`, not plain `sh`.

## Notes
This intentionally does not change the unrelated Rustup example.
