### PR TITLE
feat: show progress during edge resolution

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -294,7 +294,9 @@ fn index_files(
     db.clear_edges()?;
 
     // Resolve calls to edges
-    for (caller_id, callee_name, line) in &pending_calls {
+    let total_calls = pending_calls.len();
+    let is_tty = std::io::stderr().is_terminal();
+    for (i, (caller_id, callee_name, line)) in pending_calls.iter().enumerate() {
         db.insert_call(*caller_id, callee_name, *line as i64)?;
 
         if let Some(targets) = symbol_map.get(callee_name.as_str()) {
@@ -319,6 +321,16 @@ fn index_files(
                 Some(callee_name),
             )?;
             stats.edges += 1;
+        }
+
+        if !verbose && is_tty && (i + 1) % 500 == 0 {
+            eprint!(
+                "\r  {} files indexed, resolving edges... {}/{}",
+                stats.files,
+                i + 1,
+                total_calls
+            );
+            let _ = std::io::stderr().flush();
         }
     }
 


### PR DESCRIPTION
## Summary
- Edge resolution on large repos (8K+ files) showed no progress after "resolving edges..." — looked stuck
- Now shows `resolving edges... N/total` counter updating every 500 calls
- Terminal-only (suppressed in pipes/hooks)

## Test plan
- [x] `cargo test --test integration` — 54 tests pass
- [x] Tested on pruner repo (57 files) — progress works
- [ ] Test on large repo (8K+ files) to verify edge counter is visible