### PR TITLE
fix: hook skips non-repo dirs, add dev tooling

### DIFF
--- a/.claude/hooks/pruner-context.sh
+++ b/.claude/hooks/pruner-context.sh
@@ -49,6 +49,13 @@ fi
 
 # Run pruner context on the project directory
 REPO="${CLAUDE_PROJECT_DIR:-.}"
+
+# Only run if this looks like a code repo (has .git or .pruner already).
+# Avoids creating .pruner/ in random directories like ~ or ~/Downloads.
+if [ ! -d "$REPO/.git" ] && [ ! -d "$REPO/.pruner" ]; then
+  exit 0
+fi
+
 OUTPUT=$("$PRUNER" context "$REPO" "$PROMPT" 2>/dev/null)
 
 if [ -n "$OUTPUT" ]; then

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release install run test test-quick test-unit test-integration bench lint format check clean index
+.PHONY: build release install run test test-quick test-unit test-integration bench lint format check clean index dev-purge dev-test-install
 
 build:
 	cargo build
@@ -42,3 +42,54 @@ run:
 
 index:
 	cargo run -- index . -v
+
+# ============================================================================
+# Dev targets — these touch global config files outside this repo!
+# ============================================================================
+
+# Remove all pruner artifacts from global Claude/Copilot config and PATH.
+# Use this to test a fresh install experience.
+dev-purge:
+	@echo "⚠️  WARNING: This removes pruner from global config files."
+	@echo "   - ~/.claude/skills/pruner/"
+	@echo "   - ~/.claude/hooks/pruner-context.sh"
+	@echo "   - ~/.claude/settings.json (pruner hooks)"
+	@echo "   - ~/.copilot/skills/pruner/"
+	@echo "   - ~/.copilot/copilot-instructions.md (pruner section)"
+	@echo "   - ~/.local/bin/pruner"
+	@echo "   - /opt/homebrew/bin/pruner (if present)"
+	@echo "   - ~/.cargo/bin/pruner (if present)"
+	@echo ""
+	@read -p "Continue? [y/N] " confirm && [ "$$confirm" = "y" ] || (echo "Aborted."; exit 1)
+	rm -rf ~/.claude/skills/pruner
+	rm -f ~/.claude/hooks/pruner-context.sh
+	@if [ -f ~/.claude/settings.json ]; then \
+		python3 -c "import json,sys; s=json.load(open(sys.argv[1])); s.pop('hooks',None); json.dump(s,open(sys.argv[1],'w'),indent=2)" ~/.claude/settings.json && \
+		echo "Cleaned hooks from ~/.claude/settings.json"; \
+	fi
+	rm -rf ~/.copilot/skills/pruner
+	@if [ -f ~/.copilot/copilot-instructions.md ]; then \
+		python3 -c "import sys; t=open(sys.argv[1]).read(); i=t.find('## Pruner'); open(sys.argv[1],'w').write(t[:i].rstrip()+'\n' if i>=0 else t)" ~/.copilot/copilot-instructions.md && \
+		echo "Cleaned pruner section from ~/.copilot/copilot-instructions.md"; \
+	fi
+	rm -f ~/.local/bin/pruner
+	rm -f ~/.cargo/bin/pruner
+	@if [ -f /opt/homebrew/bin/pruner ]; then \
+		echo "Found /opt/homebrew/bin/pruner — removing (may need sudo)"; \
+		rm -f /opt/homebrew/bin/pruner || sudo rm -f /opt/homebrew/bin/pruner; \
+	fi
+	@echo ""
+	@echo "Done. Run 'make dev-test-install' to test a fresh install."
+
+# Build, install to ~/.local/bin, and run init --global --hook.
+dev-test-install: release
+	@echo "⚠️  WARNING: This installs pruner globally and modifies ~/.claude/ config."
+	@echo ""
+	@read -p "Continue? [y/N] " confirm && [ "$$confirm" = "y" ] || (echo "Aborted."; exit 1)
+	ln -sf $(CURDIR)/target/release/pruner /opt/homebrew/bin/pruner
+	@echo "Installed symlink -> /opt/homebrew/bin/pruner -> $(CURDIR)/target/release/pruner"
+	pruner --version
+	@echo ""
+	pruner init --global --hook
+	@echo ""
+	@echo "Done. Open Claude Code in any repo to test the hook."

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -284,6 +284,26 @@ mod hooks {
         );
     }
 
+    #[test]
+    fn claude_hook_skips_non_repo_directory() {
+        let dir = TempDir::new().unwrap(); // empty dir, no .git or .pruner
+        let script = hook_script(".claude/hooks/pruner-context.sh");
+        let json = r#"{"prompt": "test query"}"#;
+        let env = [("CLAUDE_PROJECT_DIR", dir.path().to_str().unwrap())];
+
+        let (code, stdout, _stderr) = run_hook(&script, json, &env);
+
+        assert_eq!(code, 0);
+        assert!(
+            stdout.is_empty(),
+            "should produce no output for non-repo directory"
+        );
+        assert!(
+            !dir.path().join(".pruner").exists(),
+            "should not create .pruner/ in non-repo directory"
+        );
+    }
+
     // -- Copilot hook tests --
 
     #[test]


### PR DESCRIPTION
## Summary
- **Hook skips non-repo directories** — checks for `.git/` or `.pruner/` before running, prevents creating `.pruner/` in random dirs like `~` or `~/Downloads`
- **Dev tooling** — `make dev-purge` to clean all pruner from global config, `make dev-test-install` for fresh global install testing

## Test plan
- [x] `cargo test --test integration` — 55 tests pass (new: `claude_hook_skips_non_repo_directory`)
- [ ] Verify hook exits silently when opening Claude in `~/Downloads`