### PR TITLE
fix: clarify README about .pruner/ directory creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ pruner init --global          # Claude Code skill mode
 pruner init --copilot-skill --copilot-global  # Copilot CLI skill mode
 ```
 
-This writes config files to `~/.claude/` or `~/.copilot/` — nothing is added to your repositories. The repository is **not indexed at install time**. On your first prompt in a repo, pruner auto-indexes it, creating a `.pruner/` directory. For large repositories (10K+ files), this first-run indexing can take 30-60 seconds. To avoid waiting, pre-index repos you use often:
+This writes config files to `~/.claude/` or `~/.copilot/`. The repository is **not indexed at install time**. On your first prompt in a repo, pruner auto-indexes it, creating a `.pruner/` directory inside the repo (add it to `.gitignore`). For large repositories (10K+ files), this first-run indexing can take 30-60 seconds. To avoid waiting, pre-index repos you use often:
 
 ```bash
 pruner index /path/to/project


### PR DESCRIPTION
## Summary

- Remove misleading claim that "nothing is added to your repositories" — pruner creates `.pruner/` inside each repo
- Add inline reminder to add `.pruner/` to `.gitignore`

## Test plan

- [x] README text is accurate