### PR TITLE
feat: score and rank subrepos in multi-repo context

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -956,7 +956,11 @@ fn cmd_context(
     Ok(())
 }
 
+/// Minimum fraction of top subrepo score a subrepo must reach to be included.
+const MULTI_REPO_SCORE_THRESHOLD: f64 = 0.3;
+
 /// Run context across multiple sub-repos and combine output.
+/// Scores each subrepo by relevance, drops low-scoring ones, and sorts by score.
 fn cmd_context_multi(
     parent: &Path,
     subrepos: &[PathBuf],
@@ -968,28 +972,85 @@ fn cmd_context_multi(
 ) -> Result<()> {
     eprintln!("Multi-repo mode: {} sub-repos found", subrepos.len());
 
-    let mut combined_text = String::new();
-    let mut combined_json: Vec<serde_json::Value> = Vec::new();
-
+    // Phase 1: score all subrepos
+    let mut scored: Vec<(&PathBuf, query::QueryResult, i32)> = Vec::new();
     for subrepo in subrepos {
         let db = open_or_create_db(subrepo, false)?;
-        let repo_path = subrepo.canonicalize()?;
         let result = query::analyze_query(ask, &db)?;
 
-        // Skip sub-repos with no relevant results
         if result.matching_files.is_empty() && result.matching_symbols.is_empty() {
             continue;
         }
 
+        let score = result.relevance_score();
+        scored.push((subrepo, result, score));
+    }
+
+    if scored.is_empty() {
+        eprintln!("No relevant results found in any sub-repo.");
+        return Ok(());
+    }
+
+    // Phase 2: filter out low-scoring subrepos relative to the best
+    let max_score = scored.iter().map(|(_, _, s)| *s).max().unwrap_or(0);
+    let threshold = (max_score as f64 * MULTI_REPO_SCORE_THRESHOLD) as i32;
+
+    let mut skipped_names: Vec<String> = Vec::new();
+    scored.retain(|(subrepo, _, score)| {
+        let name = subrepo
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        if *score < threshold {
+            eprintln!("  Skipping {name} (score {score} < threshold {threshold})");
+            skipped_names.push(name);
+            false
+        } else {
+            eprintln!("  Including {name} (score {score})");
+            true
+        }
+    });
+
+    // Phase 3: sort by score descending (most relevant first)
+    scored.sort_by(|a, b| b.2.cmp(&a.2));
+
+    // Phase 4: generate context output with multi-repo header
+    let mut combined_text = String::new();
+    let mut combined_json: Vec<serde_json::Value> = Vec::new();
+
+    // Inject multi-repo awareness header for the LLM
+    let included_names: Vec<String> = scored
+        .iter()
+        .map(|(s, _, _)| {
+            s.file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_default()
+        })
+        .collect();
+
+    if fmt != "json" {
+        combined_text.push_str("**Multi-repo context:** results from ");
+        combined_text.push_str(&included_names.join(", "));
+        if !skipped_names.is_empty() {
+            combined_text.push_str(&format!(
+                " (skipped low-relevance: {})",
+                skipped_names.join(", ")
+            ));
+        }
+        combined_text.push_str("\n\n");
+    }
+
+    for (subrepo, result, _score) in &scored {
+        let repo_path = subrepo.canonicalize()?;
+
         let resolved = if mode == ContextMode::Auto {
-            detect_mode(&result)
+            detect_mode(result)
         } else {
             mode
         };
 
-        let ctx = context::generate_context(&result, &repo_path, max_snippet_lines, resolved)?;
+        let ctx = context::generate_context(result, &repo_path, max_snippet_lines, resolved)?;
 
-        // Use relative path from parent for cleaner display
         let repo_name = subrepo
             .strip_prefix(parent)
             .unwrap_or(subrepo)
@@ -1017,15 +1078,24 @@ fn cmd_context_multi(
         }
     }
 
-    if combined_text.is_empty() && combined_json.is_empty() {
-        eprintln!("No relevant results found in any sub-repo.");
-        return Ok(());
-    }
-
     match fmt {
-        "json" => println!("{}", serde_json::to_string_pretty(&combined_json)?),
+        "json" => {
+            let wrapper = serde_json::json!({
+                "multi_repo": true,
+                "included": included_names,
+                "skipped": skipped_names,
+                "repos": combined_json,
+            });
+            println!("{}", serde_json::to_string_pretty(&wrapper)?);
+        }
         "both" => {
-            let json_str = serde_json::to_string_pretty(&combined_json)?;
+            let wrapper = serde_json::json!({
+                "multi_repo": true,
+                "included": included_names,
+                "skipped": skipped_names,
+                "repos": combined_json,
+            });
+            let json_str = serde_json::to_string_pretty(&wrapper)?;
             println!("{combined_text}");
             if let Some(out) = output {
                 fs::write(out.join("context.json"), &json_str)?;

--- a/src/query.rs
+++ b/src/query.rs
@@ -110,6 +110,16 @@ impl From<TraceRow> for PathStep {
 }
 
 impl QueryResult {
+    /// Aggregate relevance score for ranking across multiple repos.
+    /// Combines file count, symbol count, execution path depth, and test coverage.
+    pub fn relevance_score(&self) -> i32 {
+        let file_score = self.matching_files.len() as i32 * 10;
+        let symbol_score = self.matching_symbols.len() as i32 * 5;
+        let path_score: i32 = self.execution_paths.iter().map(|p| p.len() as i32).sum();
+        let test_score = self.related_tests.len() as i32 * 3;
+        file_score + symbol_score + path_score + test_score
+    }
+
     /// All unique file IDs referenced in this result.
     pub fn all_relevant_file_ids(&self) -> HashSet<i64> {
         let mut ids = HashSet::new();
@@ -1465,5 +1475,29 @@ mod tests {
         let path = trace_execution_path_cte(&start, &db, 5)?;
         assert_eq!(path.len(), 1);
         Ok(())
+    }
+
+    #[test]
+    fn test_relevance_score_proportional() {
+        let empty = QueryResult {
+            ask: "test".into(),
+            keywords: vec![],
+            matching_files: vec![],
+            matching_symbols: vec![],
+            related_tests: vec![],
+            execution_paths: vec![],
+            subsystems: vec![],
+        };
+        assert_eq!(empty.relevance_score(), 0);
+
+        let db = IndexDb::open_memory().unwrap();
+        db.insert_file("a.py", Some("python"), 10, 100, false, 0)
+            .unwrap();
+        let files = db.search_files("a.py").unwrap();
+        let with_files = QueryResult {
+            matching_files: files,
+            ..empty
+        };
+        assert!(with_files.relevance_score() > 0);
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -459,6 +459,75 @@ mod multi_repo {
     }
 
     #[test]
+    fn context_multi_repo_ranks_by_relevance() {
+        // Meta-repo with two sub-repos: webapp has auth symbols, rust_crate does not.
+        // Query for "authenticate" should put webapp first.
+        let meta = TempDir::new().unwrap();
+
+        // Sub-repo that should score HIGH for "authenticate"
+        let sub_webapp = meta.path().join("webapp");
+        let fixture1 = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/python_webapp");
+        std::fs::create_dir_all(&sub_webapp).unwrap();
+        copy_dir_all(&fixture1, &sub_webapp).unwrap();
+        make_git_dir(&sub_webapp);
+        pruner()
+            .args(["index", sub_webapp.to_str().unwrap()])
+            .assert()
+            .success();
+
+        // Sub-repo that should score LOW for "authenticate"
+        let sub_rust = meta.path().join("rust_crate");
+        let fixture2 = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/rust_crate");
+        std::fs::create_dir_all(&sub_rust).unwrap();
+        copy_dir_all(&fixture2, &sub_rust).unwrap();
+        make_git_dir(&sub_rust);
+        pruner()
+            .args(["index", sub_rust.to_str().unwrap()])
+            .assert()
+            .success();
+
+        let output = pruner()
+            .args([
+                "context",
+                meta.path().to_str().unwrap(),
+                "authenticate user login",
+            ])
+            .output()
+            .unwrap();
+
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        // Verify scoring info is logged
+        assert!(
+            stderr.contains("Including webapp"),
+            "webapp should be included, got stderr: {stderr}"
+        );
+
+        // Multi-repo header should be present
+        assert!(
+            stdout.contains("**Multi-repo context:**"),
+            "should have multi-repo header, got: {stdout}"
+        );
+
+        // webapp should appear first in output (highest score)
+        let webapp_pos = stdout.find("# Repo: webapp");
+        assert!(
+            webapp_pos.is_some(),
+            "webapp should appear in output, got: {stdout}"
+        );
+
+        // If rust_crate appears, it should be after webapp
+        if let Some(rust_pos) = stdout.find("# Repo: rust_crate") {
+            assert!(
+                webapp_pos.unwrap() < rust_pos,
+                "webapp should appear before rust_crate (higher relevance)"
+            );
+        }
+    }
+
+    #[test]
     fn context_skips_non_git_dirs() {
         let meta = TempDir::new().unwrap();
 


### PR DESCRIPTION
## Summary

- Score each subrepo by query relevance (files, symbols, execution paths, tests) and sort by score descending so the most relevant repo appears first
- Filter out subrepos scoring below 30% of the top scorer to reduce noise from loosely-matching repos
- Inject a `**Multi-repo context:**` header into LLM output listing included/skipped repos
- JSON output wraps results with `multi_repo`, `included`, and `skipped` metadata fields

## Test plan

- [x] New integration test `context_multi_repo_ranks_by_relevance` verifies highest-scoring subrepo appears first
- [x] New unit test `test_relevance_score_proportional` verifies scoring function
- [x] All 72 existing tests pass
- [x] Manual test against `nexus-meta` repository confirms correct ordering