### PR TITLE
fix: normalize hook path to forward slashes on Windows

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -505,7 +505,7 @@ fn cmd_init(
                     "matcher": "",
                     "hooks": [{
                         "type": "command",
-                        "command": hook_path.to_str().unwrap(),
+                        "command": path_to_hook_command(&hook_path),
                         "timeout": 60
                     }]
                 }]
@@ -1409,4 +1409,32 @@ fn cmd_estimate(
         }
     }
     Ok(())
+}
+
+/// Convert a path to a forward-slash string for use in shell commands.
+/// On Windows, `PathBuf::to_str` returns backslash-separated paths. Bash (used
+/// by Claude Code to execute hooks) treats backslashes as escape sequences, so
+/// `C:\Users\foo` becomes `C:Usersfoo`. Forward slashes work on all platforms.
+fn path_to_hook_command(path: &std::path::Path) -> String {
+    path.to_str().unwrap().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn test_hook_command_uses_forward_slashes() {
+        // Windows-style path with backslashes — must be normalised to forward slashes
+        // so that bash (used by Claude Code to run hooks) does not interpret them as
+        // escape sequences (which would turn C:\Users\foo into C:Usersfoo).
+        let hook_path = Path::new(r"C:\Users\testuser\.claude\hooks\pruner-context.sh");
+        let command = path_to_hook_command(hook_path);
+        assert!(
+            !command.contains('\\'),
+            "hook command path must use forward slashes for bash compatibility, got: {command}"
+        );
+        assert_eq!(command, "C:/Users/testuser/.claude/hooks/pruner-context.sh");
+    }
 }


### PR DESCRIPTION
## Problem

When running `pruner init --global --hook` on Windows, the hook command written to `settings.json` contains
backslash-separated paths (e.g. `C:\Users\foo\.claude\hooks\pruner-context.sh`).

Claude Code executes hooks through bash, which treats backslashes as escape sequences. This silently corrupts the path
 — `C:\Users\foo` becomes `C:Usersfoo` — causing a **UserPromptSubmit hook error** on every prompt.

Fixes #31.

## Root Cause

`src/cli.rs` line 508 used `hook_path.to_str().unwrap()` directly. On Windows, `PathBuf::to_str()` returns the native
backslash form.

## Fix

Extracted a `path_to_hook_command(path: &Path) -> String` helper that replaces backslashes with forward slashes before
 writing to `settings.json`. Forward slashes work universally — on Unix, bash-on-Windows, and the Windows API.

## Test

Added `cli::tests::test_hook_command_uses_forward_slashes` which passes a Windows-style path through the helper and
asserts the result contains no backslashes.


