### PR TITLE
docs: add note on Claude Code 1-hour TTL cache and A/B test implications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Note (2026-03-31):** A bug report revealed that Claude Code uses a 1-hour TTL cache — longer than the 5-minute TTL documented publicly. This likely influences the A/B test results: the current tests run long enough to exceed the 5-minute window, but not to fully account for the 1-hour cache. To isolate its impact, the tests would need to either be run multiple times or be redesigned to control for cache state.
+
 # Pruner
 
 **Cut AI coding costs by 8-44% with Claude Code. Speed up any agent by 61-80%.**


### PR DESCRIPTION
## Summary

- Adds a note at the top of README explaining that Claude Code uses a 1-hour TTL cache (longer than the 5-minute TTL documented publicly)
- Notes that this likely influences A/B test results and that tests would need to be run differently to fully account for the longer cache window