### PR TITLE
feat: cache-aware A/B test with warmup and validation

### DIFF
--- a/tests/ab_test.py
+++ b/tests/ab_test.py
@@ -85,6 +85,8 @@ def parse_args():
                         help="Pruner delivery mode: hook (prompt-submit) or skill (tool call)")
     parser.add_argument("--save-raw", action="store_true",
                         help="Save raw stream-json output for analysis")
+    parser.add_argument("--validate-cache", action="store_true",
+                        help="Warn if cache hit rates differ >10%% between paired runs")
     return parser.parse_args()
 
 
@@ -301,6 +303,87 @@ def ensure_pruner_on_path():
     return bin_dir
 
 
+def compute_cache_hit_rate(result):
+    """Compute first-turn cache hit rate from per_message_usage.
+
+    Returns the fraction of first-turn input tokens that came from cache.
+    The first turn is the best signal for whether the prompt prefix was warm,
+    since it sends the system prompt + tool schemas before any conversation.
+
+    Mutates result dict to add 'first_turn_cache_rate' key.
+    Returns the rate (float 0.0-1.0) or None if no usage data.
+    """
+    pmu = result.get("per_message_usage", [])
+    if not pmu:
+        return None
+    first = pmu[0]
+    total = first["input_tokens"] + first["cache_read"] + first["cache_creation"]
+    if total == 0:
+        return None
+    rate = first["cache_read"] / total
+    result["first_turn_cache_rate"] = rate
+    return rate
+
+
+def validate_cache_symmetry(results, threshold=0.10):
+    """Check if cache hit rates differ significantly between paired runs.
+
+    Returns a list of warning strings for pairs where the absolute difference
+    in first_turn_cache_rate exceeds the threshold.
+    """
+    warnings = []
+    for entry in results:
+        without = entry.get("without")
+        with_p = entry.get("with_pruner")
+        if not without or not with_p:
+            continue
+        rate_wo = without.get("first_turn_cache_rate")
+        rate_w = with_p.get("first_turn_cache_rate")
+        if rate_wo is None or rate_w is None:
+            continue
+        diff = abs(rate_w - rate_wo)
+        if diff > threshold:
+            warnings.append(
+                f"{entry['category']}: cache rate diff={diff:.0%} "
+                f"(without={rate_wo:.0%}, with={rate_w:.0%})"
+            )
+    return warnings
+
+
+def warmup_cache(repo_dir):
+    """Run a minimal throwaway Claude prompt to prime the prompt cache.
+
+    Anthropic's prompt cache (~1 hour TTL) caches the system prompt + tool
+    schemas prefix. This warmup ensures both sides start with equally warm
+    caches, eliminating asymmetric first-call cache advantages.
+    """
+    wrapper = WORK_DIR / "run_claude.sh"
+    if not wrapper.exists():
+        wrapper.write_text("#!/bin/bash\ncd \"$1\" && shift && exec claude \"$@\"\n")
+        wrapper.chmod(0o755)
+
+    bin_dir = ensure_pruner_on_path()
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+
+    label = Path(repo_dir).name
+    print(f"  Cache warmup [{label}] ...", file=sys.stderr)
+
+    try:
+        subprocess.run(
+            [str(wrapper), str(repo_dir),
+             "-p", "hello",
+             "--output-format", "stream-json",
+             "--max-turns", "1",
+             "--model", MODEL,
+             "--permission-mode", "bypassPermissions",
+             "--no-session-persistence"],
+            capture_output=True, text=True, timeout=120, env=env,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"  Cache warmup [{label}] timed out (continuing)", file=sys.stderr)
+
+
 def run_claude(prompt, repo_dir, label="", save_raw=False):
     """Run claude -p inside the repo directory and return parsed results."""
     wrapper = WORK_DIR / "run_claude.sh"
@@ -350,9 +433,13 @@ def print_detailed_results(label, data):
         print(f"\n  [{label}] No data", file=sys.stderr)
         return
 
+    cache_str = ""
+    cache_rate = data.get("first_turn_cache_rate")
+    if cache_rate is not None:
+        cache_str = f" cache={cache_rate:.0%}"
     print(f"\n  [{label}] Summary: turns={data['turns']} tools={data['tool_calls']} "
           f"tokens={data['total_tokens']:,} (in={data['input_tokens']:,} out={data['output_tokens']:,}) "
-          f"cost=${data['cost_usd']:.4f} time={data['wall_time_s']}s",
+          f"cost=${data['cost_usd']:.4f} time={data['wall_time_s']}s{cache_str}",
           file=sys.stderr)
 
     # Per-turn tool breakdown
@@ -407,12 +494,15 @@ def run_single(category, prompt, side, mode="hook", save_raw=False):
 
     if side == "with":
         reset_clone(CLONE_WITH, reinstall_pruner=True, mode=mode)
+        warmup_cache(CLONE_WITH)
         result = run_claude(prompt, CLONE_WITH, f"{category}/with", save_raw)
     else:
         reset_clone(CLONE_WITHOUT)
+        warmup_cache(CLONE_WITHOUT)
         result = run_claude(prompt, CLONE_WITHOUT, f"{category}/without", save_raw)
 
     if result:
+        compute_cache_hit_rate(result)
         print_detailed_results(f"{category}/{side}", result)
     return result
 
@@ -421,8 +511,8 @@ def interleaved_schedule(tasks, only=None):
     """Build a randomized run schedule where same-scenario runs are never adjacent.
 
     Each task produces two runs (with/without). The schedule interleaves them
-    so that Anthropic's prompt cache (~5 min TTL) expires between same-scenario
-    runs, eliminating cache-warming bias.
+    so that Anthropic's prompt cache (~1 hour TTL for eligible users) has less
+    opportunity for cross-scenario cache contamination.
     """
     runs = []
     for category, prompt in tasks:
@@ -470,10 +560,11 @@ def print_summary(results):
     print(
         f"  {'Task':<16} {'W/O tokens':>12} {'W/ tokens':>12} {'Δ tok':>8} "
         f"{'W/O cost':>10} {'W/ cost':>10} {'Δ cost':>8} "
-        f"{'W/O tools':>10} {'W/ tools':>10} {'Δ time':>10}",
+        f"{'W/O tools':>10} {'W/ tools':>10} {'Δ time':>10} "
+        f"{'Cache W/O':>10} {'Cache W/':>10}",
         file=sys.stderr,
     )
-    print("  " + "-" * 120, file=sys.stderr)
+    print("  " + "-" * 140, file=sys.stderr)
     for r in valid:
         w = r["without"]
         p = r["with_pruner"]
@@ -481,13 +572,18 @@ def print_summary(results):
         if w["wall_time_s"] and p["wall_time_s"]:
             td = (p["wall_time_s"] - w["wall_time_s"]) / w["wall_time_s"] * 100
             time_delta = f"{td:+.0f}%"
+        cache_wo = w.get("first_turn_cache_rate")
+        cache_w = p.get("first_turn_cache_rate")
+        cache_wo_str = f"{cache_wo:.0%}" if cache_wo is not None else "N/A"
+        cache_w_str = f"{cache_w:.0%}" if cache_w is not None else "N/A"
         print(
             f"  {r['category']:<16} {w['total_tokens']:>12,} {p['total_tokens']:>12,} "
             f"{r['token_delta_pct']:>+7.0f}% "
             f"${w['cost_usd']:>9.4f} ${p['cost_usd']:>9.4f} "
             f"{r['cost_delta_pct']:>+7.0f}% "
             f"{w['tool_calls']:>10} {p['tool_calls']:>10} "
-            f"{time_delta:>10}",
+            f"{time_delta:>10} "
+            f"{cache_wo_str:>10} {cache_w_str:>10}",
             file=sys.stderr,
         )
 
@@ -545,6 +641,16 @@ def main():
 
     # Summary to stderr
     print_summary(results)
+
+    # Cache symmetry validation
+    if args.validate_cache:
+        cache_warnings = validate_cache_symmetry(results)
+        if cache_warnings:
+            print(f"\n  CACHE WARNINGS:", file=sys.stderr)
+            for w in cache_warnings:
+                print(f"    {w}", file=sys.stderr)
+        else:
+            print(f"\n  Cache symmetry OK (all pairs within 10%)", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_ab_test.py
+++ b/tests/test_ab_test.py
@@ -11,7 +11,11 @@ import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from ab_test import interleaved_schedule, parse_stream, ensure_pruner_on_path, TASKS, PRUNER_BIN, WORK_DIR
+from ab_test import (
+    interleaved_schedule, parse_stream, ensure_pruner_on_path,
+    compute_cache_hit_rate, validate_cache_symmetry,
+    TASKS, PRUNER_BIN, WORK_DIR,
+)
 from ab_test_copilot import (
     interleaved_schedule as copilot_interleaved_schedule,
     ensure_pruner_on_path as copilot_ensure_pruner_on_path,
@@ -183,6 +187,132 @@ class TestParseStream:
         result = parse_stream(stream)
         assert len(result["per_message_usage"]) == 1
         assert result["per_message_usage"][0]["turn"] == 1
+
+
+class TestComputeCacheHitRate:
+    def test_all_cached(self):
+        result = {
+            "per_message_usage": [
+                {"turn": 1, "input_tokens": 100, "cache_read": 900, "cache_creation": 0, "output_tokens": 50},
+            ],
+        }
+        rate = compute_cache_hit_rate(result)
+        assert rate == 0.9
+        assert result["first_turn_cache_rate"] == 0.9
+
+    def test_no_cache(self):
+        result = {
+            "per_message_usage": [
+                {"turn": 1, "input_tokens": 1000, "cache_read": 0, "cache_creation": 500, "output_tokens": 50},
+            ],
+        }
+        rate = compute_cache_hit_rate(result)
+        assert rate == 0.0
+        assert result["first_turn_cache_rate"] == 0.0
+
+    def test_empty_usage_returns_none(self):
+        result = {"per_message_usage": []}
+        rate = compute_cache_hit_rate(result)
+        assert rate is None
+        assert result.get("first_turn_cache_rate") is None
+
+    def test_missing_usage_returns_none(self):
+        result = {}
+        rate = compute_cache_hit_rate(result)
+        assert rate is None
+
+    def test_only_first_turn_used(self):
+        result = {
+            "per_message_usage": [
+                {"turn": 1, "input_tokens": 200, "cache_read": 800, "cache_creation": 0, "output_tokens": 50},
+                {"turn": 2, "input_tokens": 50, "cache_read": 950, "cache_creation": 0, "output_tokens": 50},
+            ],
+        }
+        rate = compute_cache_hit_rate(result)
+        assert rate == 0.8  # 800 / (200 + 800 + 0), not turn 2's rate
+
+    def test_zero_total_returns_none(self):
+        result = {
+            "per_message_usage": [
+                {"turn": 1, "input_tokens": 0, "cache_read": 0, "cache_creation": 0, "output_tokens": 0},
+            ],
+        }
+        rate = compute_cache_hit_rate(result)
+        assert rate is None
+
+
+class TestValidateCacheSymmetry:
+    def test_symmetric_rates_no_warning(self):
+        results = [{
+            "category": "narrow_fix",
+            "without": {"first_turn_cache_rate": 0.85},
+            "with_pruner": {"first_turn_cache_rate": 0.85},
+        }]
+        warnings = validate_cache_symmetry(results)
+        assert warnings == []
+
+    def test_asymmetric_rates_warns(self):
+        results = [{
+            "category": "narrow_fix",
+            "without": {"first_turn_cache_rate": 0.70},
+            "with_pruner": {"first_turn_cache_rate": 0.90},
+        }]
+        warnings = validate_cache_symmetry(results)
+        assert len(warnings) == 1
+        assert "narrow_fix" in warnings[0]
+
+    def test_missing_rate_skips(self):
+        results = [{
+            "category": "narrow_fix",
+            "without": {"first_turn_cache_rate": 0.85},
+            "with_pruner": {},
+        }]
+        warnings = validate_cache_symmetry(results)
+        assert warnings == []
+
+    def test_missing_side_skips(self):
+        results = [{
+            "category": "narrow_fix",
+            "without": {"first_turn_cache_rate": 0.85},
+            "with_pruner": None,
+        }]
+        warnings = validate_cache_symmetry(results)
+        assert warnings == []
+
+    def test_multiple_tasks_mixed(self):
+        results = [
+            {
+                "category": "narrow_fix",
+                "without": {"first_turn_cache_rate": 0.85},
+                "with_pruner": {"first_turn_cache_rate": 0.84},
+            },
+            {
+                "category": "cross_package",
+                "without": {"first_turn_cache_rate": 0.50},
+                "with_pruner": {"first_turn_cache_rate": 0.90},
+            },
+        ]
+        warnings = validate_cache_symmetry(results)
+        assert len(warnings) == 1
+        assert "cross_package" in warnings[0]
+
+    def test_threshold_boundary_no_warning(self):
+        results = [{
+            "category": "narrow_fix",
+            "without": {"first_turn_cache_rate": 0.80},
+            "with_pruner": {"first_turn_cache_rate": 0.90},
+        }]
+        warnings = validate_cache_symmetry(results, threshold=0.10)
+        assert warnings == []  # exactly 0.10 is not > 0.10
+
+    def test_custom_threshold(self):
+        results = [{
+            "category": "narrow_fix",
+            "without": {"first_turn_cache_rate": 0.80},
+            "with_pruner": {"first_turn_cache_rate": 0.86},
+        }]
+        warnings = validate_cache_symmetry(results, threshold=0.05)
+        assert len(warnings) == 1
 
 
 class TestEnsurePrunerOnPath:


### PR DESCRIPTION
## Summary

- Add cache warmup before each measured run to equalize prompt cache state between "with" and "without" sides
- Anthropic's 1-hour TTL prompt cache is shared across sessions (keyed by content/org, not session ID), creating asymmetric cost advantages for the side with more API calls
- New `--validate-cache` flag warns if first-turn cache rates differ >10% between paired runs
- Summary table now shows cache hit rate columns for transparency

## Changes

- `warmup_cache()` — throwaway "hello" prompt to prime cache before each measured run
- `compute_cache_hit_rate()` — extract first-turn cache rate from per_message_usage
- `validate_cache_symmetry()` — post-run validation of cache rate symmetry
- 13 new tests covering all cache-aware functions

## Test plan

- [x] `uv run --with pytest pytest tests/test_ab_test.py -v` — 43 tests pass
- [x] Manual A/B run: `python3 tests/ab_test.py --task narrow_fix --save-raw --validate-cache`
- [x] Manual A/B run: `python3 tests/ab_test.py --task data_flow --save-raw --validate-cache`