### PR TITLE
docs: add C# to supported languages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ Full tree-sitter parsing (symbols, imports, calls):
 - Java
 - C
 - C++
+- C#
 
 Basic indexing (files, metadata):
 


### PR DESCRIPTION
## Summary

- Add C# to the supported languages list in README.md