### PR TITLE
feat: add first-party Codex integration

### DIFF
--- a/.codex/hooks/pruner-context.sh
+++ b/.codex/hooks/pruner-context.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Codex UserPromptSubmit hook: runs pruner context and injects output as extra developer context.
+# Stdin: JSON with .prompt and .cwd. Stdout: plain text added as developer context.
+
+INPUT=$(cat)
+
+if command -v jq >/dev/null 2>&1; then
+  PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
+  CWD=$(echo "$INPUT" | jq -r '.cwd // "."')
+else
+  PROMPT=$(echo "$INPUT" | sed -n 's/.*"prompt" *: *"\(.*\)"/\1/p' | sed 's/",".*//; s/",.*//')
+  CWD=$(pwd)
+fi
+
+if [ -z "$PROMPT" ]; then
+  exit 0
+fi
+
+# Find pruner binary: PATH first, then common install locations, then dev build
+PRUNER=$(command -v pruner 2>/dev/null)
+if [ -z "$PRUNER" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
+  candidates=(
+    "$HOME/.local/bin/pruner"
+    "$HOME/.local/bin/pruner.exe"
+    "$HOME/.cargo/bin/pruner"
+    "$SCRIPT_DIR/../../target/release/pruner"
+    "$SCRIPT_DIR/../../target/release/pruner.exe"
+  )
+  if [ -d "/usr/local/bin" ]; then
+    candidates+=("/usr/local/bin/pruner")
+  fi
+  if [ -n "$USERPROFILE" ]; then
+    candidates+=("$USERPROFILE/.local/bin/pruner.exe")
+  fi
+  for candidate in "${candidates[@]}"; do
+    if [ -f "$candidate" ]; then
+      PRUNER="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "$PRUNER" ] || [ ! -f "$PRUNER" ]; then
+  exit 0
+fi
+
+REPO="${CWD:-.}"
+
+HAS_INDEX=false
+if [ -e "$REPO/.git" ] || [ -d "$REPO/.pruner" ]; then
+  HAS_INDEX=true
+fi
+if [ "$HAS_INDEX" = false ]; then
+  for d in "$REPO"/*/; do
+    if [ -e "${d}.git" ] || [ -f "${d}.pruner/index.db" ]; then
+      HAS_INDEX=true
+      break
+    fi
+  done
+fi
+if [ "$HAS_INDEX" = false ]; then
+  exit 0
+fi
+
+OUTPUT=$("$PRUNER" context "$REPO" "$PROMPT" 2>/dev/null)
+
+if [ -n "$OUTPUT" ]; then
+  echo "## Pruner context (pre-computed codebase analysis)"
+  echo ""
+  echo "$OUTPUT"
+fi
+
+exit 0

--- a/.codex/hooks/pruner-context.sh
+++ b/.codex/hooks/pruner-context.sh
@@ -7,9 +7,12 @@ INPUT=$(cat)
 if command -v jq >/dev/null 2>&1; then
   PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
   CWD=$(echo "$INPUT" | jq -r '.cwd // "."')
+elif command -v python3 >/dev/null 2>&1; then
+  PROMPT=$(echo "$INPUT" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("prompt",""))' 2>/dev/null)
+  CWD=$(echo "$INPUT" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("cwd","."))' 2>/dev/null)
 else
-  PROMPT=$(echo "$INPUT" | sed -n 's/.*"prompt" *: *"\(.*\)"/\1/p' | sed 's/",".*//; s/",.*//')
-  CWD=$(pwd)
+  # No jq or python3 — cannot safely parse JSON
+  exit 0
 fi
 
 if [ -z "$PROMPT" ]; then

--- a/.codex/hooks/pruner-context.sh
+++ b/.codex/hooks/pruner-context.sh
@@ -55,12 +55,14 @@ if [ -e "$REPO/.git" ] || [ -d "$REPO/.pruner" ]; then
   HAS_INDEX=true
 fi
 if [ "$HAS_INDEX" = false ]; then
+  shopt -s nullglob 2>/dev/null || true
   for d in "$REPO"/*/; do
     if [ -e "${d}.git" ] || [ -f "${d}.pruner/index.db" ]; then
       HAS_INDEX=true
       break
     fi
   done
+  shopt -u nullglob 2>/dev/null || true
 fi
 if [ "$HAS_INDEX" = false ]; then
   exit 0

--- a/.codex/skills/pruner/SKILL.md
+++ b/.codex/skills/pruner/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: pruner
+description: Uses the local pruner indexer to gather relevant code context before making changes, debugging, refactoring, or answering questions about this repository.
+---
+
 # Pruner — automatic code context
 
 Pruner is a tree-sitter-based code indexer that pre-analyzes the entire codebase. It builds a call graph, symbol index, and file dependency map at index time, then uses your prompt keywords to find the most relevant execution paths, files, and code snippets. The output is equivalent to you running dozens of search and file-read calls, but computed in seconds from a pre-built index.

--- a/.codex/skills/pruner/SKILL.md
+++ b/.codex/skills/pruner/SKILL.md
@@ -1,0 +1,10 @@
+# Pruner — automatic code context
+
+Pruner is a tree-sitter-based code indexer that pre-analyzes the entire codebase. It builds a call graph, symbol index, and file dependency map at index time, then uses your prompt keywords to find the most relevant execution paths, files, and code snippets. The output is equivalent to you running dozens of search and file-read calls, but computed in seconds from a pre-built index.
+
+Before making code changes, fixing bugs, refactoring, or answering questions about this codebase:
+
+1. Get context: `pruner context /absolute/path/to/repo "<task description>"` and read the output first.
+2. Work directly from the output. Only read source files if a snippet is truncated or you need nearby lines.
+3. Use `--detail` when brief pointers are not enough for tracing or debugging.
+4. Do not re-explore the same query with grep, glob, or rg right after pruner.

--- a/AGENTS.template.md
+++ b/AGENTS.template.md
@@ -1,0 +1,8 @@
+## Pruner — automatic code context
+
+Before making code changes, fixing bugs, refactoring, or answering questions about this codebase:
+
+1. Get context: `pruner context . "<task description>"` and read the output first.
+2. Work directly from the output. Only read source files if a snippet is truncated or you need surrounding context.
+3. Use `--detail` when brief pointers are not enough for tracing or debugging.
+4. Do not re-explore the same query with grep, glob, or rg right after pruner.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ walkdir = "2"
 ignore = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 regex = "1"
 anyhow = "1"
 dirs = "6"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pruner eliminates this. It pre-indexes your entire repository using plain struct
 | Implementation (small) | **15%** | **44%** | **59%** |
 | Narrow fix | **6%** | **39%** | **21%** |
 
-Works with **Claude Code** (recommended, via prompt-submit hook), **Codex**, **Copilot**, or any agent that can run a CLI command. Claude Code users save on both cost and time. Copilot users save time ([Copilot results](#ab-test-results-copilot-cli)) — Copilot pricing is per premium request regardless of tool calls, so pruner speeds up tasks without affecting cost.
+Works with **Claude Code** (recommended, via prompt-submit hook), **Codex**, **Copilot**, or any agent that can run a CLI command. Claude Code users save on both cost and time. Codex supports both **skills** and a **UserPromptSubmit hook**. Copilot users save time ([Copilot results](#ab-test-results-copilot-cli)) — Copilot pricing is per premium request regardless of tool calls, so pruner speeds up tasks without affecting cost.
 
 ## Install
 
@@ -41,6 +41,12 @@ curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.s
 
 # Copilot CLI skill, global
 curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.sh | bash -s -- --copilot-skill --copilot-global
+
+# Codex skill, global
+curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.sh | bash -s -- --codex --codex-global
+
+# Codex hook, global (experimental; non-Windows)
+curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.sh | bash -s -- --codex-hook --codex-global
 
 # Just install the binary, no setup
 curl -sSf https://raw.githubusercontent.com/heikki-laitala/pruner/main/install.sh | bash -s -- --no-interactive
@@ -85,6 +91,8 @@ Install once — pruner works automatically in every git repository:
 pruner init --global --hook   # Claude Code hook mode (best for one-shot tasks)
 pruner init --global          # Claude Code skill mode
 pruner init --copilot-skill --copilot-global  # Copilot CLI skill mode
+pruner init --codex --codex-global            # Codex skill mode
+pruner init --codex-hook --codex-global       # Codex hook mode (experimental)
 ```
 
 This writes config files to `~/.claude/` or `~/.copilot/`. The repository is **not indexed at install time**. On your first prompt in a repo, pruner auto-indexes it, creating a `.pruner/` directory inside the repo (add it to `.gitignore`). For large repositories (10K+ files), this first-run indexing takes ~10 seconds. To avoid waiting, pre-index repos you use often:
@@ -108,6 +116,8 @@ pruner init /path/to/project --hook          # Claude Code hook mode
 pruner init /path/to/project                 # Claude Code skill mode
 pruner init /path/to/project --copilot-skill # Copilot CLI skill mode
 pruner init /path/to/project --copilot-hook  # Copilot CLI hook mode
+pruner init /path/to/project --codex         # Codex skill mode
+pruner init /path/to/project --codex-hook    # Codex hook mode (experimental)
 ```
 
 This creates config files inside the repo (`.claude/` or `.copilot/`), updates `.gitignore` to exclude `.pruner/`, and auto-indexes the project.
@@ -169,6 +179,28 @@ Then in Copilot CLI:
 Requires `--experimental` flag in Copilot CLI 1.0.x. The hook runs on `userPromptSubmitted` and writes `.pruner/copilot-context.md`.
 
 **Note:** Copilot's `userPromptSubmitted` hook is observational — the model doesn't wait for it to complete before starting. On large repos, the model may start exploring before the context file is written. For reliable results, use **skill mode**.
+
+### Codex integration
+
+| Mode | How it works | Setup |
+|------|-------------|-------|
+| **Skill** | Codex runs `pruner context` as a tool | `pruner init --codex --codex-global` |
+| **Hook** (experimental) | Codex `UserPromptSubmit` hook injects pruner output as extra developer context | `pruner init --codex-hook --codex-global` |
+
+**Skill mode** creates:
+- `.codex/skills/pruner/SKILL.md` (global: `~/.codex/skills/pruner/SKILL.md`)
+- `AGENTS.md` guidance for per-project installs
+
+**Hook mode** creates:
+- `.codex/hooks/pruner-context.sh` (global: `~/.codex/hooks/pruner-context.sh`)
+- `.codex/hooks.json`
+- `.codex/config.toml` with `[features] codex_hooks = true`
+- `AGENTS.md` guidance for per-project installs
+
+**Notes:**
+- Codex hooks are experimental and disabled on Windows in current Codex docs.
+- Repo-local Codex hook config lives in `.codex/hooks.json` and is discovered by Codex automatically.
+- The hook injects the output of `pruner context` as extra developer context before the prompt is sent.
 
 ### What happens automatically
 

--- a/install.ps1
+++ b/install.ps1
@@ -13,6 +13,9 @@
 #   PRUNER_GLOBAL       Set to "1" to install globally (~/.claude/)
 #   PRUNER_COPILOT_SKILL  Set to "1" for Copilot CLI skill
 #   PRUNER_COPILOT_GLOBAL Set to "1" for global Copilot skill
+#   PRUNER_CODEX          Set to "1" for Codex skill
+#   PRUNER_CODEX_HOOK     Set to "1" for Codex hook
+#   PRUNER_CODEX_GLOBAL   Set to "1" for global Codex integration
 #   PRUNER_NO_INTERACTIVE Set to "1" to skip prompts
 
 $ErrorActionPreference = "Stop"
@@ -24,8 +27,11 @@ $Hook = $env:PRUNER_HOOK -eq "1"
 $Global = $env:PRUNER_GLOBAL -eq "1"
 $CopilotSkill = $env:PRUNER_COPILOT_SKILL -eq "1"
 $CopilotGlobal = $env:PRUNER_COPILOT_GLOBAL -eq "1"
+$Codex = $env:PRUNER_CODEX -eq "1"
+$CodexHook = $env:PRUNER_CODEX_HOOK -eq "1"
+$CodexGlobal = $env:PRUNER_CODEX_GLOBAL -eq "1"
 $NoInteractive = $env:PRUNER_NO_INTERACTIVE -eq "1"
-$HasSetupFlags = $Hook -or $Global -or $CopilotSkill -or $CopilotGlobal
+$HasSetupFlags = $Hook -or $Global -or $CopilotSkill -or $CopilotGlobal -or $Codex -or $CodexHook -or $CodexGlobal
 
 # Resolve version
 if (-not $Version -or $Version -eq "latest") {
@@ -94,7 +100,8 @@ if (-not $HasSetupFlags -and -not $NoInteractive) {
     Write-Host "  1) Claude Code  (global - works in every repo)"
     Write-Host "  2) Copilot CLI  (global - works in every repo)"
     Write-Host "  3) Both Claude Code + Copilot CLI (global)"
-    Write-Host "  4) Skip - I'll set up later with 'pruner init'"
+    Write-Host "  4) Codex (global)"
+    Write-Host "  5) Skip - I'll set up later with 'pruner init'"
     Write-Host ""
     $Choice = Read-Host "Choice [1]"
     if ([string]::IsNullOrWhiteSpace($Choice)) { $Choice = "1" }
@@ -129,10 +136,29 @@ if (-not $HasSetupFlags -and -not $NoInteractive) {
             if ($Mode -eq "1") { $Hook = $true }
         }
         "4" {
+            $CodexGlobal = $true
+            Write-Host ""
+            Write-Host "Codex mode:"
+            Write-Host "  1) Skill - Codex calls pruner as a tool"
+            Write-Host "  2) Hook - UserPromptSubmit hook injects context (experimental)"
+            Write-Host "  3) Both"
+            Write-Host ""
+            $Mode = Read-Host "Choice [1]"
+            if ([string]::IsNullOrWhiteSpace($Mode)) { $Mode = "1" }
+            switch ($Mode) {
+                "1" { $Codex = $true }
+                "2" { $CodexHook = $true }
+                "3" { $Codex = $true; $CodexHook = $true }
+                default { $Codex = $true }
+            }
+        }
+        "5" {
             Write-Host ""
             Write-Host "To set up later:"
             Write-Host "  pruner init --global --hook          # Claude Code (recommended)"
             Write-Host "  pruner init --copilot-skill --copilot-global  # Copilot CLI"
+            Write-Host "  pruner init --codex --codex-global   # Codex skill"
+            Write-Host "  pruner init --codex-hook --codex-global  # Codex hook (experimental)"
             Write-Host "  pruner init C:\path\to\project --hook  # per-project"
             Write-Host ""
             Write-Host "Done."
@@ -155,8 +181,11 @@ if ($Hook) { $InitArgs += "--hook" }
 if ($Global) { $InitArgs += "--global" }
 if ($CopilotSkill) { $InitArgs += "--copilot-skill" }
 if ($CopilotGlobal) { $InitArgs += "--copilot-global" }
+if ($Codex) { $InitArgs += "--codex" }
+if ($CodexHook) { $InitArgs += "--codex-hook" }
+if ($CodexGlobal) { $InitArgs += "--codex-global" }
 
-if ($Global -or $CopilotGlobal) {
+if ($Global -or $CopilotGlobal -or $CodexGlobal) {
     Write-Host "Setting up global integration..."
     & $ExePath init @InitArgs
     Write-Host ""
@@ -175,6 +204,12 @@ if ($Global -or $CopilotGlobal) {
     }
     if ($CopilotSkill) {
         Write-Host "  pruner init C:\path\to\project --copilot-skill   # Copilot CLI skill files"
+    }
+    if ($Codex) {
+        Write-Host "  pruner init C:\path\to\project --codex           # Codex skill files"
+    }
+    if ($CodexHook) {
+        Write-Host "  pruner init C:\path\to\project --codex-hook      # Codex prompt hook files"
     }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@
 # Non-interactive (flags skip the prompts):
 #   curl -sSf ... | bash -s -- --hook --global
 #   curl -sSf ... | bash -s -- --copilot-skill --copilot-global
+#   curl -sSf ... | bash -s -- --codex --codex-global
 #
 # Options (pass after --):
 #   --hook           Install Claude Code prompt-submit hook (better performance)
@@ -14,6 +15,9 @@
 #   --copilot-skill  Install Copilot CLI skill and instructions
 #   --copilot-hook   Install Copilot userPromptSubmitted hook files
 #   --copilot-global Install Copilot CLI skill globally (~/.copilot/)
+#   --codex          Install Codex skill and AGENTS.md guidance
+#   --codex-hook     Install Codex UserPromptSubmit hook
+#   --codex-global   Install Codex integration globally (~/.codex/)
 #   --dir DIR        Install binary to DIR instead of ~/.local/bin
 #   --version V      Install specific version (default: latest)
 #   --no-interactive Skip interactive prompts (just install binary)
@@ -28,6 +32,9 @@ GLOBAL=false
 COPILOT_SKILL=false
 COPILOT_HOOK=false
 COPILOT_GLOBAL=false
+CODEX=false
+CODEX_HOOK=false
+CODEX_GLOBAL=false
 NO_INTERACTIVE=false
 HAS_SETUP_FLAGS=false
 
@@ -39,17 +46,23 @@ while [ $# -gt 0 ]; do
         --copilot-skill) COPILOT_SKILL=true; HAS_SETUP_FLAGS=true ;;
         --copilot-hook) COPILOT_HOOK=true; HAS_SETUP_FLAGS=true ;;
         --copilot-global) COPILOT_GLOBAL=true; HAS_SETUP_FLAGS=true ;;
+        --codex) CODEX=true; HAS_SETUP_FLAGS=true ;;
+        --codex-hook) CODEX_HOOK=true; HAS_SETUP_FLAGS=true ;;
+        --codex-global) CODEX_GLOBAL=true; HAS_SETUP_FLAGS=true ;;
         --no-interactive) NO_INTERACTIVE=true ;;
         --dir) INSTALL_DIR="$2"; shift ;;
         --version) VERSION="$2"; shift ;;
         --help|-h)
-            echo "Usage: install.sh [--hook] [--global] [--copilot-skill] [--copilot-hook] [--copilot-global] [--dir DIR] [--version VERSION] [--no-interactive]"
+            echo "Usage: install.sh [--hook] [--global] [--copilot-skill] [--copilot-hook] [--copilot-global] [--codex] [--codex-hook] [--codex-global] [--dir DIR] [--version VERSION] [--no-interactive]"
             echo ""
             echo "  --hook           Install Claude Code prompt-submit hook (better performance)"
             echo "  --global         Install skill/hook globally (~/.claude/)"
             echo "  --copilot-skill  Install Copilot CLI skill and instructions"
             echo "  --copilot-hook   Install Copilot userPromptSubmitted hook files"
             echo "  --copilot-global Install Copilot CLI skill globally (~/.copilot/)"
+            echo "  --codex          Install Codex skill and AGENTS.md guidance"
+            echo "  --codex-hook     Install Codex UserPromptSubmit hook"
+            echo "  --codex-global   Install Codex integration globally (~/.codex/)"
             echo "  --dir DIR        Install binary to DIR (default: ~/.local/bin)"
             echo "  --version V      Install specific version (default: latest)"
             echo "  --no-interactive Skip interactive prompts (just install binary)"
@@ -153,7 +166,8 @@ if [ "$HAS_SETUP_FLAGS" = false ] && [ "$NO_INTERACTIVE" = false ] && [ -r /dev/
     echo "  1) Claude Code  (global — works in every repo)"
     echo "  2) Copilot CLI  (global — works in every repo)"
     echo "  3) Both Claude Code + Copilot CLI (global)"
-    echo "  4) Skip — I'll set up later with 'pruner init'"
+    echo "  4) Codex (global)"
+    echo "  5) Skip — I'll set up later with 'pruner init'"
     echo ""
     CHOICE=$(ask "Choice [1]:" "1")
 
@@ -189,10 +203,28 @@ if [ "$HAS_SETUP_FLAGS" = false ] && [ "$NO_INTERACTIVE" = false ] && [ -r /dev/
             fi
             ;;
         4)
+            CODEX_GLOBAL=true
+            echo ""
+            echo "Codex mode:"
+            echo "  1) Skill — Codex calls pruner as a tool"
+            echo "  2) Hook — UserPromptSubmit hook injects context (experimental)"
+            echo "  3) Both"
+            echo ""
+            MODE=$(ask "Choice [1]:" "1")
+            case "$MODE" in
+                1) CODEX=true ;;
+                2) CODEX_HOOK=true ;;
+                3) CODEX=true; CODEX_HOOK=true ;;
+                *) CODEX=true ;;
+            esac
+            ;;
+        5)
             echo ""
             echo "To set up later:"
             echo "  pruner init --global --hook          # Claude Code (recommended)"
             echo "  pruner init --copilot-skill --copilot-global  # Copilot CLI"
+            echo "  pruner init --codex --codex-global   # Codex skill"
+            echo "  pruner init --codex-hook --codex-global  # Codex hook (experimental)"
             echo "  pruner init /path/to/project --hook  # per-project"
             echo ""
             echo "Done."
@@ -226,8 +258,17 @@ fi
 if [ "$COPILOT_GLOBAL" = true ]; then
     INIT_ARGS="${INIT_ARGS} --copilot-global"
 fi
+if [ "$CODEX" = true ]; then
+    INIT_ARGS="${INIT_ARGS} --codex"
+fi
+if [ "$CODEX_HOOK" = true ]; then
+    INIT_ARGS="${INIT_ARGS} --codex-hook"
+fi
+if [ "$CODEX_GLOBAL" = true ]; then
+    INIT_ARGS="${INIT_ARGS} --codex-global"
+fi
 
-if [ "$GLOBAL" = true ] || [ "$COPILOT_GLOBAL" = true ]; then
+if [ "$GLOBAL" = true ] || [ "$COPILOT_GLOBAL" = true ] || [ "$CODEX_GLOBAL" = true ]; then
     echo "Setting up global integration..."
     "${INSTALL_DIR}/pruner" init ${INIT_ARGS}
     echo ""
@@ -249,6 +290,12 @@ elif [ "$HAS_SETUP_FLAGS" = true ]; then
     fi
     if [ "$COPILOT_HOOK" = true ]; then
         echo "  pruner init /path/to/project --copilot-hook    # Copilot prompt hook files"
+    fi
+    if [ "$CODEX" = true ]; then
+        echo "  pruner init /path/to/project --codex           # Codex skill files"
+    fi
+    if [ "$CODEX_HOOK" = true ]; then
+        echo "  pruner init /path/to/project --codex-hook      # Codex prompt hook files"
     fi
 fi
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,6 +96,28 @@ struct InitOptions {
     no_root: bool,
 }
 
+impl InitOptions {
+    fn has_non_claude_flag(&self) -> bool {
+        self.copilot_skill
+            || self.copilot_global
+            || self.copilot_hook
+            || self.codex
+            || self.codex_hook
+            || self.codex_global
+    }
+
+    fn has_any_flag(&self) -> bool {
+        self.hook
+            || self.global
+            || self.copilot_skill
+            || self.copilot_global
+            || self.copilot_hook
+            || self.codex
+            || self.codex_hook
+            || self.codex_global
+    }
+}
+
 #[derive(Subcommand)]
 enum Commands {
     /// Index a repository
@@ -482,6 +504,8 @@ const CODEX_HOOK_SCRIPT: &str = include_str!("../.codex/hooks/pruner-context.sh"
 const AGENTS_TEMPLATE: &str = include_str!("../AGENTS.template.md");
 
 fn cmd_init(repo: &Path, opts: InitOptions) -> Result<()> {
+    let has_non_claude = opts.has_non_claude_flag();
+    let has_any = opts.has_any_flag();
     let InitOptions {
         hook,
         global,
@@ -501,6 +525,10 @@ fn cmd_init(repo: &Path, opts: InitOptions) -> Result<()> {
     if codex_global && !codex && !codex_hook {
         anyhow::bail!("--codex-global requires --codex and/or --codex-hook");
     }
+    #[cfg(windows)]
+    if codex_hook {
+        eprintln!("Warning: Codex hooks are experimental and currently disabled on Windows");
+    }
 
     // Detect existing global install — skip project-level files if global hook is set up.
     // Hook injects context directly, so project-level skill/CLAUDE.md is redundant.
@@ -508,25 +536,11 @@ fn cmd_init(repo: &Path, opts: InitOptions) -> Result<()> {
     let existing = crate::upgrade::detect_installed_integrations();
     let has_global_hook = existing.hook;
 
-    let install_claude = (!copilot_skill
-        && !copilot_global
-        && !copilot_hook
-        && !codex
-        && !codex_hook
-        && !codex_global)
-        || hook
-        || global;
+    let install_claude = !has_non_claude || hook || global;
 
     // If running bare `pruner init` (no flags) and global hook is already installed,
     // skip project-level skill/CLAUDE.md — just do .gitignore + index.
-    let bare_init = !hook
-        && !global
-        && !copilot_skill
-        && !copilot_global
-        && !copilot_hook
-        && !codex
-        && !codex_hook
-        && !codex_global;
+    let bare_init = !has_any;
     let skip_claude_project = bare_init && has_global_hook;
 
     if skip_claude_project {
@@ -974,7 +988,14 @@ fn has_codex_hooks_enabled(path: &Path) -> bool {
     let Ok(content) = fs::read_to_string(path) else {
         return false;
     };
-    content.contains("codex_hooks = true")
+    let Ok(value) = content.parse::<toml::Value>() else {
+        return false;
+    };
+    value
+        .get("features")
+        .and_then(|f| f.get("codex_hooks"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
 }
 
 fn enable_codex_hooks(path: &Path) -> Result<()> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1029,6 +1029,21 @@ fn enable_codex_hooks(path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn pruner_hook_value(command: &str) -> serde_json::Value {
+    serde_json::json!({
+        "type": "command",
+        "command": command,
+        "timeout": 60,
+        "statusMessage": "Loading pruner context"
+    })
+}
+
+fn is_pruner_hook(hook: &serde_json::Value) -> bool {
+    hook.get("command")
+        .and_then(|c| c.as_str())
+        .is_some_and(|c| c.contains("pruner-context"))
+}
+
 fn upsert_codex_hook(path: &Path, command: &str) -> Result<()> {
     let mut config: serde_json::Value = if path.exists() {
         serde_json::from_str(&fs::read_to_string(path)?)?
@@ -1050,38 +1065,23 @@ fn upsert_codex_hook(path: &Path, command: &str) -> Result<()> {
         .as_array_mut()
         .ok_or_else(|| anyhow::anyhow!("Codex UserPromptSubmit hooks must be an array"))?;
 
+    // Replace the pruner hook in-place within whichever entry contains it,
+    // leaving any sibling hooks from other tools untouched.
+    let new_hook = pruner_hook_value(command);
     let mut replaced = false;
     for entry in submit.iter_mut() {
         let Some(entry_hooks) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) else {
             continue;
         };
-        if entry_hooks.iter().any(|hook| {
-            hook.get("command")
-                .and_then(|c| c.as_str())
-                .is_some_and(|c| c.contains("pruner-context"))
-        }) {
-            *entry = serde_json::json!({
-                "hooks": [{
-                    "type": "command",
-                    "command": command,
-                    "timeout": 60,
-                    "statusMessage": "Loading pruner context"
-                }]
-            });
+        if let Some(existing) = entry_hooks.iter_mut().find(|h| is_pruner_hook(h)) {
+            *existing = new_hook.clone();
             replaced = true;
             break;
         }
     }
 
     if !replaced {
-        submit.push(serde_json::json!({
-            "hooks": [{
-                "type": "command",
-                "command": command,
-                "timeout": 60,
-                "statusMessage": "Loading pruner context"
-            }]
-        }));
+        submit.push(serde_json::json!({ "hooks": [new_hook] }));
     }
 
     if let Some(parent) = path.parent() {
@@ -1891,5 +1891,108 @@ mod tests {
             command,
             "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/pruner-context.sh\""
         );
+    }
+
+    #[test]
+    fn test_upsert_codex_hook_creates_new_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hooks.json");
+        upsert_codex_hook(&path, "bash /tmp/pruner-context.sh").unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let submit = config["hooks"]["UserPromptSubmit"].as_array().unwrap();
+        assert_eq!(submit.len(), 1);
+        let hooks = submit[0]["hooks"].as_array().unwrap();
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0]["command"], "bash /tmp/pruner-context.sh");
+        assert_eq!(hooks[0]["timeout"], 60);
+    }
+
+    #[test]
+    fn test_upsert_codex_hook_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hooks.json");
+        upsert_codex_hook(&path, "bash /tmp/pruner-context.sh").unwrap();
+        upsert_codex_hook(&path, "bash /tmp/pruner-context.sh").unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let submit = config["hooks"]["UserPromptSubmit"].as_array().unwrap();
+        assert_eq!(
+            submit.len(),
+            1,
+            "repeated upsert must not duplicate entries"
+        );
+    }
+
+    #[test]
+    fn test_upsert_codex_hook_preserves_sibling_hooks() {
+        // A prior entry with a sibling hook from another tool must not be clobbered
+        // when we replace the pruner hook in the same entry.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hooks.json");
+        let initial = serde_json::json!({
+            "hooks": {
+                "UserPromptSubmit": [{
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "bash /old/pruner-context.sh",
+                            "timeout": 30
+                        },
+                        {
+                            "type": "command",
+                            "command": "bash /opt/other-tool.sh",
+                            "timeout": 10
+                        }
+                    ]
+                }]
+            }
+        });
+        fs::write(&path, serde_json::to_string_pretty(&initial).unwrap()).unwrap();
+
+        upsert_codex_hook(&path, "bash /new/pruner-context.sh").unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let hooks = config["hooks"]["UserPromptSubmit"][0]["hooks"]
+            .as_array()
+            .unwrap();
+        assert_eq!(hooks.len(), 2, "sibling hook must be preserved");
+        let commands: Vec<&str> = hooks
+            .iter()
+            .map(|h| h["command"].as_str().unwrap())
+            .collect();
+        assert!(commands.contains(&"bash /new/pruner-context.sh"));
+        assert!(commands.contains(&"bash /opt/other-tool.sh"));
+    }
+
+    #[test]
+    fn test_enable_codex_hooks_new_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        enable_codex_hooks(&path).unwrap();
+
+        assert!(has_codex_hooks_enabled(&path));
+    }
+
+    #[test]
+    fn test_enable_codex_hooks_preserves_existing_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            "model = \"gpt-5\"\n\n[features]\nsome_other_flag = true\n",
+        )
+        .unwrap();
+
+        enable_codex_hooks(&path).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let parsed: toml::Value = content.parse().unwrap();
+        assert_eq!(parsed["model"].as_str(), Some("gpt-5"));
+        assert_eq!(parsed["features"]["some_other_flag"].as_bool(), Some(true));
+        assert_eq!(parsed["features"]["codex_hooks"].as_bool(), Some(true));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1435,7 +1435,7 @@ fn cmd_context_multi(
     });
 
     // Phase 3: sort by score descending (most relevant first)
-    scored.sort_by(|a, b| b.2.cmp(&a.2));
+    scored.sort_by_key(|b| std::cmp::Reverse(b.2));
 
     // Phase 4: generate context output with multi-repo header
     let mut combined_text = String::new();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,6 +84,18 @@ struct Cli {
     command: Commands,
 }
 
+struct InitOptions {
+    hook: bool,
+    global: bool,
+    copilot_skill: bool,
+    copilot_hook: bool,
+    copilot_global: bool,
+    codex: bool,
+    codex_hook: bool,
+    codex_global: bool,
+    no_root: bool,
+}
+
 #[derive(Subcommand)]
 enum Commands {
     /// Index a repository
@@ -153,7 +165,7 @@ enum Commands {
         #[arg(default_value = ".")]
         repo: PathBuf,
     },
-    /// Set up pruner in a project (Claude/Copilot skills, hook, instructions)
+    /// Set up pruner in a project (Claude/Copilot/Codex skills, hooks, instructions)
     Init {
         /// Path to the project
         #[arg(default_value = ".")]
@@ -173,6 +185,15 @@ enum Commands {
         /// Install Copilot CLI skill globally (~/.copilot/)
         #[arg(long)]
         copilot_global: bool,
+        /// Install Codex skill and AGENTS.md guidance
+        #[arg(long)]
+        codex: bool,
+        /// Install Codex UserPromptSubmit hook
+        #[arg(long)]
+        codex_hook: bool,
+        /// Install Codex integration globally (~/.codex/)
+        #[arg(long)]
+        codex_global: bool,
         /// In meta-repo mode, skip indexing root directory files (only index sub-repos)
         #[arg(long)]
         no_root: bool,
@@ -229,15 +250,23 @@ pub fn run() -> Result<()> {
             copilot_skill,
             copilot_hook,
             copilot_global,
+            codex,
+            codex_hook,
+            codex_global,
             no_root,
         } => cmd_init(
             &repo,
-            hook,
-            global,
-            copilot_skill,
-            copilot_hook,
-            copilot_global,
-            no_root,
+            InitOptions {
+                hook,
+                global,
+                copilot_skill,
+                copilot_hook,
+                copilot_global,
+                codex,
+                codex_hook,
+                codex_global,
+                no_root,
+            },
         ),
         Commands::Index {
             repo,
@@ -448,20 +477,29 @@ const COPILOT_TEMPLATE_HOOK: &str = include_str!("../COPILOT.template.hook.md");
 const COPILOT_HOOK_JSON: &str = include_str!("../.copilot/hooks/pruner-context.json");
 const COPILOT_HOOK_BASH: &str = include_str!("../.copilot/hooks/pruner-context.sh");
 const COPILOT_HOOK_PS1: &str = include_str!("../.copilot/hooks/pruner-context.ps1");
+const CODEX_SKILL_MD: &str = include_str!("../.codex/skills/pruner/SKILL.md");
+const CODEX_HOOK_SCRIPT: &str = include_str!("../.codex/hooks/pruner-context.sh");
+const AGENTS_TEMPLATE: &str = include_str!("../AGENTS.template.md");
 
-fn cmd_init(
-    repo: &Path,
-    hook: bool,
-    global: bool,
-    copilot_skill: bool,
-    copilot_hook: bool,
-    copilot_global: bool,
-    no_root: bool,
-) -> Result<()> {
+fn cmd_init(repo: &Path, opts: InitOptions) -> Result<()> {
+    let InitOptions {
+        hook,
+        global,
+        copilot_skill,
+        copilot_hook,
+        copilot_global,
+        codex,
+        codex_hook,
+        codex_global,
+        no_root,
+    } = opts;
     if copilot_hook && copilot_global {
         anyhow::bail!(
             "--copilot-hook is repository-local; do not combine it with --copilot-global"
         );
+    }
+    if codex_global && !codex && !codex_hook {
+        anyhow::bail!("--codex-global requires --codex and/or --codex-hook");
     }
 
     // Detect existing global install — skip project-level files if global hook is set up.
@@ -470,11 +508,25 @@ fn cmd_init(
     let existing = crate::upgrade::detect_installed_integrations();
     let has_global_hook = existing.hook;
 
-    let install_claude = (!copilot_skill && !copilot_global && !copilot_hook) || hook || global;
+    let install_claude = (!copilot_skill
+        && !copilot_global
+        && !copilot_hook
+        && !codex
+        && !codex_hook
+        && !codex_global)
+        || hook
+        || global;
 
     // If running bare `pruner init` (no flags) and global hook is already installed,
     // skip project-level skill/CLAUDE.md — just do .gitignore + index.
-    let bare_init = !hook && !global && !copilot_skill && !copilot_global && !copilot_hook;
+    let bare_init = !hook
+        && !global
+        && !copilot_skill
+        && !copilot_global
+        && !copilot_hook
+        && !codex
+        && !codex_hook
+        && !codex_global;
     let skip_claude_project = bare_init && has_global_hook;
 
     if skip_claude_project {
@@ -535,7 +587,7 @@ fn cmd_init(
         }
     }
 
-    if !global && !copilot_global {
+    if !global && !copilot_global && !codex_global {
         // Add .pruner/ to .gitignore
         let gitignore = repo.join(".gitignore");
         let gitignore_content = if gitignore.exists() {
@@ -630,7 +682,58 @@ fn cmd_init(
         }
     }
 
-    if (!global && install_claude) || ((copilot_skill || copilot_hook) && !copilot_global) {
+    if codex || codex_hook || codex_global {
+        let codex_base = if codex_global {
+            dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
+                .join(".codex")
+        } else {
+            repo.join(".codex")
+        };
+
+        if codex {
+            let codex_skill_dir = codex_base.join("skills").join("pruner");
+            fs::create_dir_all(&codex_skill_dir)?;
+            fs::write(codex_skill_dir.join("SKILL.md"), CODEX_SKILL_MD)?;
+            println!(
+                "Installed Codex skill -> {}",
+                codex_skill_dir.join("SKILL.md").display()
+            );
+        }
+
+        if codex_hook {
+            let hook_dir = codex_base.join("hooks");
+            fs::create_dir_all(&hook_dir)?;
+            let hook_path = hook_dir.join("pruner-context.sh");
+            fs::write(&hook_path, CODEX_HOOK_SCRIPT)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755))?;
+            }
+            println!("Installed Codex hook -> {}", hook_path.display());
+
+            let hooks_path = codex_base.join("hooks.json");
+            let hook_command = codex_hook_command(&hook_path, codex_global);
+            upsert_codex_hook(&hooks_path, &hook_command)?;
+            println!("Updated Codex hooks -> {}", hooks_path.display());
+
+            let config_path = codex_base.join("config.toml");
+            enable_codex_hooks(&config_path)?;
+            println!("Updated Codex config -> {}", config_path.display());
+        }
+
+        if !codex_global {
+            let agents_md = repo.join("AGENTS.md");
+            upsert_pruner_section(&agents_md, AGENTS_TEMPLATE)?;
+            println!("Updated AGENTS.md -> {}", agents_md.display());
+        }
+    }
+
+    if (!global && install_claude)
+        || ((copilot_skill || copilot_hook) && !copilot_global)
+        || ((codex || codex_hook) && !codex_global)
+    {
         println!("\nIndexing {}...", repo.display());
         cmd_index(repo, false, no_root)?;
     }
@@ -687,6 +790,30 @@ fn cmd_status(repo: Option<&Path>) -> Result<()> {
         println!("  Copilot:     not installed");
     }
 
+    let codex_dir = home.join(".codex");
+    let codex_skill = codex_dir.join("skills/pruner/SKILL.md").exists();
+    let codex_hook_file = codex_dir.join("hooks/pruner-context.sh").exists();
+    let codex_hooks_json = has_codex_hook(&codex_dir.join("hooks.json"));
+    let codex_hooks_enabled = has_codex_hooks_enabled(&codex_dir.join("config.toml"));
+
+    if codex_skill || codex_hook_file || codex_hooks_json {
+        print!("  Codex:       ");
+        let mut parts = Vec::new();
+        if codex_skill {
+            parts.push("skill");
+        }
+        if codex_hook_file || codex_hooks_json {
+            parts.push("hook");
+        }
+        print!("{}", parts.join(" + "));
+        if (codex_hook_file || codex_hooks_json) && !codex_hooks_enabled {
+            print!(" (feature flag missing)");
+        }
+        println!("  (~/.codex/)");
+    } else {
+        println!("  Codex:       not installed");
+    }
+
     // --- Per-project integrations ---
     if let Some(repo) = repo {
         println!();
@@ -735,6 +862,32 @@ fn cmd_status(repo: Option<&Path>) -> Result<()> {
             println!("  Copilot:     {}", parts.join(" + "));
         } else {
             println!("  Copilot:     not installed");
+        }
+
+        let proj_codex_skill = repo.join(".codex/skills/pruner/SKILL.md").exists();
+        let proj_codex_hook_file = repo.join(".codex/hooks/pruner-context.sh").exists();
+        let proj_codex_hooks_json = has_codex_hook(&repo.join(".codex/hooks.json"));
+        let proj_codex_hooks_enabled = has_codex_hooks_enabled(&repo.join(".codex/config.toml"));
+        let proj_agents_md = has_pruner_section(&repo.join("AGENTS.md"));
+
+        if proj_codex_skill || proj_codex_hook_file || proj_codex_hooks_json || proj_agents_md {
+            let mut parts = Vec::new();
+            if proj_codex_skill {
+                parts.push("skill");
+            }
+            if proj_codex_hook_file || proj_codex_hooks_json {
+                parts.push("hook");
+            }
+            if proj_agents_md {
+                parts.push("AGENTS.md");
+            }
+            let mut suffix = String::new();
+            if (proj_codex_hook_file || proj_codex_hooks_json) && !proj_codex_hooks_enabled {
+                suffix.push_str(" (feature flag missing)");
+            }
+            println!("  Codex:       {}{}", parts.join(" + "), suffix);
+        } else {
+            println!("  Codex:       not installed");
         }
 
         // Index status
@@ -807,6 +960,114 @@ pub(crate) fn has_pruner_section(path: &Path) -> bool {
         return false;
     };
     content.contains("## Pruner")
+}
+
+/// Check if a Codex hooks.json file contains a pruner hook entry.
+pub(crate) fn has_codex_hook(path: &Path) -> bool {
+    let Ok(content) = fs::read_to_string(path) else {
+        return false;
+    };
+    content.contains("pruner-context")
+}
+
+fn has_codex_hooks_enabled(path: &Path) -> bool {
+    let Ok(content) = fs::read_to_string(path) else {
+        return false;
+    };
+    content.contains("codex_hooks = true")
+}
+
+fn enable_codex_hooks(path: &Path) -> Result<()> {
+    let current = if path.exists() {
+        fs::read_to_string(path)?
+    } else {
+        String::new()
+    };
+
+    let mut value = if current.trim().is_empty() {
+        toml::Value::Table(toml::map::Map::new())
+    } else {
+        current.parse::<toml::Value>()?
+    };
+
+    let root = value
+        .as_table_mut()
+        .ok_or_else(|| anyhow::anyhow!("Codex config must be a TOML table"))?;
+    let features = root
+        .entry("features")
+        .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+    let features = features
+        .as_table_mut()
+        .ok_or_else(|| anyhow::anyhow!("Codex features config must be a TOML table"))?;
+    features.insert("codex_hooks".into(), toml::Value::Boolean(true));
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, toml::to_string_pretty(&value)?)?;
+    Ok(())
+}
+
+fn upsert_codex_hook(path: &Path, command: &str) -> Result<()> {
+    let mut config: serde_json::Value = if path.exists() {
+        serde_json::from_str(&fs::read_to_string(path)?)?
+    } else {
+        serde_json::json!({})
+    };
+
+    let root = config
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Codex hooks.json must be a JSON object"))?;
+    let hooks = root
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Codex hooks field must be an object"))?;
+    let submit = hooks
+        .entry("UserPromptSubmit")
+        .or_insert_with(|| serde_json::json!([]))
+        .as_array_mut()
+        .ok_or_else(|| anyhow::anyhow!("Codex UserPromptSubmit hooks must be an array"))?;
+
+    let mut replaced = false;
+    for entry in submit.iter_mut() {
+        let Some(entry_hooks) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) else {
+            continue;
+        };
+        if entry_hooks.iter().any(|hook| {
+            hook.get("command")
+                .and_then(|c| c.as_str())
+                .is_some_and(|c| c.contains("pruner-context"))
+        }) {
+            *entry = serde_json::json!({
+                "hooks": [{
+                    "type": "command",
+                    "command": command,
+                    "timeout": 60,
+                    "statusMessage": "Loading pruner context"
+                }]
+            });
+            replaced = true;
+            break;
+        }
+    }
+
+    if !replaced {
+        submit.push(serde_json::json!({
+            "hooks": [{
+                "type": "command",
+                "command": command,
+                "timeout": 60,
+                "statusMessage": "Loading pruner context"
+            }]
+        }));
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_string_pretty(&config)?)?;
+    Ok(())
 }
 
 fn cmd_index(repo: &Path, verbose: bool, no_root: bool) -> Result<()> {
@@ -1564,6 +1825,14 @@ fn path_to_hook_command(path: &std::path::Path) -> String {
     path.to_str().unwrap().replace('\\', "/")
 }
 
+fn codex_hook_command(path: &std::path::Path, global: bool) -> String {
+    if global {
+        format!("bash \"{}\"", path_to_hook_command(path))
+    } else {
+        "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/pruner-context.sh\"".to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1581,5 +1850,25 @@ mod tests {
             "hook command path must use forward slashes for bash compatibility, got: {command}"
         );
         assert_eq!(command, "C:/Users/testuser/.claude/hooks/pruner-context.sh");
+    }
+
+    #[test]
+    fn test_codex_global_hook_command_uses_absolute_path() {
+        let hook_path = Path::new(r"C:\Users\testuser\.codex\hooks\pruner-context.sh");
+        let command = codex_hook_command(hook_path, true);
+        assert_eq!(
+            command,
+            "bash \"C:/Users/testuser/.codex/hooks/pruner-context.sh\""
+        );
+    }
+
+    #[test]
+    fn test_codex_project_hook_command_uses_git_root() {
+        let hook_path = Path::new("/tmp/repo/.codex/hooks/pruner-context.sh");
+        let command = codex_hook_command(hook_path, false);
+        assert_eq!(
+            command,
+            "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/pruner-context.sh\""
+        );
     }
 }

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -1464,4 +1464,99 @@ mod tests {
         assert_eq!(hooks.len(), 1);
         assert!(hooks[0]["command"].as_str().unwrap().contains("other-tool"));
     }
+
+    #[test]
+    fn test_clean_codex_hooks_json_pruner_only_removes_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hooks.json");
+        let hooks = serde_json::json!({
+            "hooks": {
+                "UserPromptSubmit": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": "bash /home/u/.codex/hooks/pruner-context.sh"
+                    }]
+                }]
+            }
+        });
+        fs::write(&path, serde_json::to_string_pretty(&hooks).unwrap()).unwrap();
+
+        clean_codex_hooks_json(&path);
+
+        assert!(
+            !path.exists(),
+            "pruner-only hooks.json should be removed entirely"
+        );
+    }
+
+    #[test]
+    fn test_clean_codex_hooks_json_preserves_sibling_hooks() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hooks.json");
+        let hooks = serde_json::json!({
+            "hooks": {
+                "UserPromptSubmit": [{
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "bash /home/u/.codex/hooks/pruner-context.sh"
+                        },
+                        {
+                            "type": "command",
+                            "command": "bash /home/u/.codex/hooks/other.sh"
+                        }
+                    ]
+                }]
+            }
+        });
+        fs::write(&path, serde_json::to_string_pretty(&hooks).unwrap()).unwrap();
+
+        clean_codex_hooks_json(&path);
+
+        let content = fs::read_to_string(&path).unwrap();
+        let result: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let remaining = result["hooks"]["UserPromptSubmit"][0]["hooks"]
+            .as_array()
+            .unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert!(
+            remaining[0]["command"]
+                .as_str()
+                .unwrap()
+                .contains("other.sh")
+        );
+    }
+
+    #[test]
+    fn test_clean_codex_config_toml_pruner_only_removes_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "[features]\ncodex_hooks = true\n").unwrap();
+
+        clean_codex_config_toml(&path);
+
+        assert!(
+            !path.exists(),
+            "pruner-only config.toml should be removed entirely"
+        );
+    }
+
+    #[test]
+    fn test_clean_codex_config_toml_preserves_other_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            "model = \"gpt-5\"\n\n[features]\ncodex_hooks = true\nother_flag = true\n",
+        )
+        .unwrap();
+
+        clean_codex_config_toml(&path);
+
+        let content = fs::read_to_string(&path).unwrap();
+        let parsed: toml::Value = content.parse().unwrap();
+        assert_eq!(parsed["model"].as_str(), Some("gpt-5"));
+        assert_eq!(parsed["features"]["other_flag"].as_bool(), Some(true));
+        assert!(parsed["features"].get("codex_hooks").is_none());
+    }
 }

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -56,8 +56,8 @@ fn clean_codex_hooks_json(path: &Path) {
         if remove_file {
             let _ = fs::remove_file(path);
             println!("  Removed {} (was pruner-only)", path.display());
-        } else {
-            let _ = fs::write(path, serde_json::to_string_pretty(&config).unwrap());
+        } else if let Ok(json) = serde_json::to_string_pretty(&config) {
+            let _ = fs::write(path, json);
             println!("  Cleaned pruner hook from {}", path.display());
         }
     }
@@ -89,8 +89,8 @@ fn clean_codex_config_toml(path: &Path) {
         if config.as_table().is_some_and(|t| t.is_empty()) {
             let _ = fs::remove_file(path);
             println!("  Removed {} (was pruner-only)", path.display());
-        } else {
-            let _ = fs::write(path, toml::to_string_pretty(&config).unwrap());
+        } else if let Ok(toml_str) = toml::to_string_pretty(&config) {
+            let _ = fs::write(path, toml_str);
             println!("  Cleaned pruner hook flag from {}", path.display());
         }
     }

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -6,6 +6,96 @@ use std::fs;
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
+fn clean_codex_hooks_json(path: &Path) {
+    if !path.exists() {
+        return;
+    }
+    let Ok(content) = fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(mut config) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return;
+    };
+
+    let mut changed = false;
+    if let Some(hooks) = config.get_mut("hooks").and_then(|h| h.as_object_mut())
+        && let Some(submit) = hooks
+            .get_mut("UserPromptSubmit")
+            .and_then(|s| s.as_array_mut())
+    {
+        for entry in submit.iter_mut() {
+            if let Some(hook_arr) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) {
+                let before = hook_arr.len();
+                hook_arr.retain(|h| {
+                    !h.get("command")
+                        .and_then(|c| c.as_str())
+                        .is_some_and(|c| c.contains("pruner-context"))
+                });
+                if hook_arr.len() < before {
+                    changed = true;
+                }
+            }
+        }
+        submit.retain(|entry| {
+            entry
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .is_none_or(|a| !a.is_empty())
+        });
+        if submit.is_empty() {
+            hooks.remove("UserPromptSubmit");
+        }
+    }
+
+    if changed {
+        let remove_file = config
+            .as_object()
+            .and_then(|o| o.get("hooks"))
+            .and_then(|h| h.as_object())
+            .is_none_or(|h| h.is_empty());
+        if remove_file {
+            let _ = fs::remove_file(path);
+            println!("  Removed {} (was pruner-only)", path.display());
+        } else {
+            let _ = fs::write(path, serde_json::to_string_pretty(&config).unwrap());
+            println!("  Cleaned pruner hook from {}", path.display());
+        }
+    }
+}
+
+fn clean_codex_config_toml(path: &Path) {
+    if !path.exists() {
+        return;
+    }
+    let Ok(content) = fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(mut config) = content.parse::<toml::Value>() else {
+        return;
+    };
+
+    let mut changed = false;
+    if let Some(root) = config.as_table_mut()
+        && let Some(features) = root.get_mut("features").and_then(|f| f.as_table_mut())
+        && features.remove("codex_hooks").is_some()
+    {
+        changed = true;
+        if features.is_empty() {
+            root.remove("features");
+        }
+    }
+
+    if changed {
+        if config.as_table().is_some_and(|t| t.is_empty()) {
+            let _ = fs::remove_file(path);
+            println!("  Removed {} (was pruner-only)", path.display());
+        } else {
+            let _ = fs::write(path, toml::to_string_pretty(&config).unwrap());
+            println!("  Cleaned pruner hook flag from {}", path.display());
+        }
+    }
+}
+
 /// Remove a file if it exists, printing what was removed.
 fn remove_file(path: &Path) {
     if path.exists() {
@@ -184,6 +274,15 @@ fn uninstall_copilot_global(home: &Path) {
     remove_file(&copilot.join("hooks/pruner-context.ps1"));
 }
 
+/// Remove global Codex integrations from ~/.codex/
+fn uninstall_codex_global(home: &Path) {
+    let codex = home.join(".codex");
+    remove_dir(&codex.join("skills/pruner"));
+    remove_file(&codex.join("hooks/pruner-context.sh"));
+    clean_codex_hooks_json(&codex.join("hooks.json"));
+    clean_codex_config_toml(&codex.join("config.toml"));
+}
+
 /// Remove per-project Claude integrations
 fn uninstall_claude_project(repo: &Path) {
     let claude = repo.join(".claude");
@@ -202,6 +301,15 @@ fn uninstall_copilot_project(repo: &Path) {
     remove_file(&repo.join(".github/hooks/pruner-context.ps1"));
 }
 
+/// Remove per-project Codex integrations
+fn uninstall_codex_project(repo: &Path) {
+    remove_dir(&repo.join(".codex/skills/pruner"));
+    remove_file(&repo.join(".codex/hooks/pruner-context.sh"));
+    clean_codex_hooks_json(&repo.join(".codex/hooks.json"));
+    clean_codex_config_toml(&repo.join(".codex/config.toml"));
+    remove_pruner_section(&repo.join("AGENTS.md"));
+}
+
 // ---------------------------------------------------------------------------
 // Scan: find leftover pruner traces across the filesystem
 // ---------------------------------------------------------------------------
@@ -212,8 +320,10 @@ pub(crate) enum TraceKind {
     PrunerDir,
     ClaudeSkillDir,
     CopilotSkillDir,
+    CodexSkillDir,
     PrunerSection,
     SettingsHook,
+    CodexHookConfig,
     HookFile,
     GitignoreEntry,
 }
@@ -224,8 +334,10 @@ impl fmt::Display for TraceKind {
             TraceKind::PrunerDir => write!(f, ".pruner/ index"),
             TraceKind::ClaudeSkillDir => write!(f, "Claude skill"),
             TraceKind::CopilotSkillDir => write!(f, "Copilot skill"),
+            TraceKind::CodexSkillDir => write!(f, "Codex skill"),
             TraceKind::PrunerSection => write!(f, "pruner section"),
             TraceKind::SettingsHook => write!(f, "settings hook"),
+            TraceKind::CodexHookConfig => write!(f, "Codex hook config"),
             TraceKind::HookFile => write!(f, "hook file"),
             TraceKind::GitignoreEntry => write!(f, ".gitignore entry"),
         }
@@ -250,7 +362,10 @@ impl FoundTrace {
     /// Remove this trace using the appropriate cleanup method.
     fn remove(&self) {
         match self.kind {
-            TraceKind::PrunerDir | TraceKind::ClaudeSkillDir | TraceKind::CopilotSkillDir => {
+            TraceKind::PrunerDir
+            | TraceKind::ClaudeSkillDir
+            | TraceKind::CopilotSkillDir
+            | TraceKind::CodexSkillDir => {
                 remove_dir(&self.path);
             }
             TraceKind::HookFile => {
@@ -262,6 +377,13 @@ impl FoundTrace {
             TraceKind::SettingsHook => {
                 clean_settings_json(&self.path);
             }
+            TraceKind::CodexHookConfig => {
+                if self.path.file_name().is_some_and(|n| n == "hooks.json") {
+                    clean_codex_hooks_json(&self.path);
+                } else {
+                    clean_codex_config_toml(&self.path);
+                }
+            }
             TraceKind::GitignoreEntry => {
                 clean_gitignore(&self.path);
             }
@@ -272,7 +394,7 @@ impl FoundTrace {
 /// Infer the project root from a trace path by stripping known integration subdirs.
 /// e.g. `/home/user/myproject/.claude/skills/pruner` -> `/home/user/myproject`
 fn infer_project(path: &Path) -> PathBuf {
-    const MARKERS: &[&str] = &[".claude", ".copilot", ".github", ".pruner"];
+    const MARKERS: &[&str] = &[".claude", ".copilot", ".codex", ".github", ".pruner"];
     // Walk ancestors; the project root is the parent of the first known marker dir.
     for ancestor in path.ancestors() {
         if let Some(name) = ancestor.file_name()
@@ -341,6 +463,7 @@ fn match_dir_trace(path: &Path, name: &str) -> Option<TraceKind> {
             match parent.parent()?.file_name()?.to_str()? {
                 ".claude" => Some(TraceKind::ClaudeSkillDir),
                 ".copilot" => Some(TraceKind::CopilotSkillDir),
+                ".codex" => Some(TraceKind::CodexSkillDir),
                 _ => None,
             }
         }
@@ -358,11 +481,12 @@ fn match_file_trace(path: &Path, name: &str) -> Option<TraceKind> {
                 .and_then(|p| p.file_name())
                 .is_some_and(|n| n == "hooks");
             let parent_of_hooks = path.ancestors().nth(2).and_then(|p| p.file_name());
-            let in_integration_dir = parent_of_hooks
-                .is_some_and(|n| n == ".claude" || n == ".copilot" || n == ".github");
+            let in_integration_dir = parent_of_hooks.is_some_and(|n| {
+                n == ".claude" || n == ".copilot" || n == ".codex" || n == ".github"
+            });
             (in_hooks_dir && in_integration_dir).then_some(TraceKind::HookFile)
         }
-        "CLAUDE.md" | "copilot-instructions.md" => {
+        "CLAUDE.md" | "AGENTS.md" | "copilot-instructions.md" => {
             crate::cli::has_pruner_section(path).then_some(TraceKind::PrunerSection)
         }
         "settings.json" => {
@@ -371,6 +495,21 @@ fn match_file_trace(path: &Path, name: &str) -> Option<TraceKind> {
                 .and_then(|p| p.file_name())
                 .is_some_and(|n| n == ".claude");
             (in_claude && has_pruner_hook_entry(path)).then_some(TraceKind::SettingsHook)
+        }
+        "hooks.json" => {
+            let in_codex = path
+                .parent()
+                .and_then(|p| p.file_name())
+                .is_some_and(|n| n == ".codex");
+            (in_codex && crate::cli::has_codex_hook(path)).then_some(TraceKind::CodexHookConfig)
+        }
+        "config.toml" => {
+            let in_codex = path
+                .parent()
+                .and_then(|p| p.file_name())
+                .is_some_and(|n| n == ".codex");
+            (in_codex && fs::read_to_string(path).is_ok_and(|c| c.contains("codex_hooks = true")))
+                .then_some(TraceKind::CodexHookConfig)
         }
         ".gitignore" => {
             let content = fs::read_to_string(path).ok()?;
@@ -508,6 +647,7 @@ pub fn cmd_uninstall(repo: Option<&Path>, purge: bool) -> Result<()> {
 
         uninstall_claude_project(repo);
         uninstall_copilot_project(repo);
+        uninstall_codex_project(repo);
         clean_gitignore(&repo.join(".gitignore"));
 
         if purge {
@@ -526,6 +666,7 @@ pub fn cmd_uninstall(repo: Option<&Path>, purge: bool) -> Result<()> {
 
         uninstall_claude_global(&home);
         uninstall_copilot_global(&home);
+        uninstall_codex_global(&home);
 
         // Scan for project-level traces
         println!("\nScanning for project-level pruner traces...");

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -163,11 +163,14 @@ pub(crate) struct DetectedIntegrations {
     pub(crate) hook: bool,
     pub(crate) copilot_global: bool,
     pub(crate) copilot_skill: bool,
+    pub(crate) codex_global: bool,
+    pub(crate) codex_skill: bool,
+    pub(crate) codex_hook: bool,
 }
 
 impl DetectedIntegrations {
     fn has_any(&self) -> bool {
-        self.global || self.copilot_global
+        self.global || self.copilot_global || self.codex_global
     }
 }
 
@@ -177,12 +180,18 @@ pub(crate) fn detect_installed_integrations() -> DetectedIntegrations {
     let claude_hook = home.join(".claude/hooks/pruner-context.sh").exists();
     let claude_skill = home.join(".claude/skills/pruner/SKILL.md").exists();
     let copilot_skill = home.join(".copilot/skills/pruner/SKILL.md").exists();
+    let codex_skill = home.join(".codex/skills/pruner/SKILL.md").exists();
+    let codex_hook = home.join(".codex/hooks/pruner-context.sh").exists()
+        || crate::cli::has_codex_hook(&home.join(".codex/hooks.json"));
 
     DetectedIntegrations {
         global: claude_hook || claude_skill,
         hook: claude_hook,
         copilot_global: copilot_skill,
         copilot_skill,
+        codex_global: codex_skill || codex_hook,
+        codex_skill,
+        codex_hook,
     }
 }
 
@@ -202,6 +211,15 @@ fn reinit_integrations(integrations: &DetectedIntegrations) -> Result<()> {
     }
     if integrations.copilot_skill && !integrations.copilot_global {
         args.push("--copilot-skill".to_string());
+    }
+    if integrations.codex_global {
+        args.push("--codex-global".to_string());
+    }
+    if integrations.codex_skill {
+        args.push("--codex".to_string());
+    }
+    if integrations.codex_hook {
+        args.push("--codex-hook".to_string());
     }
 
     eprintln!(
@@ -329,6 +347,9 @@ mod tests {
             hook: false,
             copilot_global: false,
             copilot_skill: false,
+            codex_global: false,
+            codex_skill: false,
+            codex_hook: false,
         };
         assert!(!d.has_any());
     }
@@ -340,6 +361,9 @@ mod tests {
             hook: true,
             copilot_global: false,
             copilot_skill: false,
+            codex_global: false,
+            codex_skill: false,
+            codex_hook: false,
         };
         assert!(d.has_any());
     }
@@ -351,6 +375,9 @@ mod tests {
             hook: false,
             copilot_global: true,
             copilot_skill: true,
+            codex_global: false,
+            codex_skill: false,
+            codex_hook: false,
         };
         assert!(d.has_any());
     }


### PR DESCRIPTION
## Summary
- add first-party Codex support to `pruner init`, including `--codex`, `--codex-hook`, and `--codex-global`
- install Codex-native skill, hook script, `hooks.json`, `config.toml` feature flag wiring, and `AGENTS.md` guidance
- extend `status`, `uninstall`, `upgrade`, installers, and README to understand Codex integrations

## Validation
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test --bin pruner`