### PR TITLE
refactor: return error instead of panicking on non-UTF-8 hook paths

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -204,16 +204,6 @@ Natural seams exist at: keyword extraction/stemming/fuzzy (~lines 776–889), sy
 - `integrations/claude_code.rs`, `integrations/copilot.rs`, `integrations/codex.rs`
 - `cmd_init`/`cmd_status`/uninstall command iterate over `&[Box<dyn Integration>]`
 
-### 22. Surface cleanup errors in `uninstall.rs`
-
-13 `let _ = fs::…` swallows plus 109 `unwrap`s. The user sees a success message even when cleanup partially fails (e.g. permissions error, missing config file, JSON parse failure on a user-edited settings.json).
-
-**Implementation:**
-
-- Collect into `Vec<UninstallWarning { path, reason }>` instead of discarding
-- Print a "Cleanup completed with warnings:" block at end of command when non-empty
-- Keep best-effort semantics (don't abort on first error), just report
-
 ### 23. Offline query replay subcommand (unblock scoring iteration)
 
 TODO #9 already flags evaluation as the bottleneck for iterating on scoring. The posthoc script exists but runs against saved Claude sessions — it doesn't let you compare "files pruner would suggest at HEAD vs. branch" directly.
@@ -327,6 +317,8 @@ Add optional embedding-based search for queries that don't match symbol/file nam
 - [x] Keyword stemming + bidirectional prefix matching (`rust-stemmers` Snowball English). Stem-based candidate gathering and scoring fallback. No posthoc recall change yet — narrow_fix bottleneck is keyword quality ("handle" drowning out "reconnection"), not stemming
 - [x] Keyword IDF weighting: `idf = min(file_idf, sym_idf)` with stem-aware hit counts. Rare keywords contribute more to scoring. Posthoc: openclaw recall 40% → 43%, implement 79% → 83%, narrow_fix 0% → 40%
 - [x] TS/JS parser: JSX components as call edges, dynamic `import()` as imports, re-export tracking (`export { X } from './module'`). Barrel file full resolution and React Compiler detection deferred
+- [x] Uninstall: surface cleanup errors instead of swallowing them. `let _ = fs::…` replaced with warning-collecting helpers; "Cleanup completed with warnings:" block printed when non-empty, best-effort semantics preserved
+- [x] Installer: non-UTF-8 hook paths return an `anyhow` error with clear message instead of panicking via `to_str().unwrap()`
 
 ## Explored but rejected
 

--- a/TODO.md
+++ b/TODO.md
@@ -241,12 +241,6 @@ Iterates every file, splits each path on `/`, checks each component against a sc
 
 **Implementation:** `.par_iter().map(|f| (f, score_file(..))).collect()`. Gated behind a candidate-count threshold so small repos don't pay thread-pool startup.
 
-### 26. `path.to_str().unwrap()` in hook-install path (cli.rs ~1881)
-
-Non-UTF-8 project paths panic the installer. Rare on macOS, possible on Windows.
-
-**Implementation:** switch to `path.to_string_lossy().into_owned()` or surface via `anyhow::Context` with a clear "project path is not valid UTF-8" message.
-
 ## Low priority / future
 
 ### 13. Post-session accuracy feedback loop

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -587,12 +587,13 @@ fn cmd_init(repo: &Path, opts: InitOptions) -> Result<()> {
             } else {
                 serde_json::json!({})
             };
+            let hook_command = path_to_hook_command(&hook_path)?;
             settings["hooks"] = serde_json::json!({
                 "UserPromptSubmit": [{
                     "matcher": "",
                     "hooks": [{
                         "type": "command",
-                        "command": path_to_hook_command(&hook_path),
+                        "command": hook_command,
                         "timeout": 60
                     }]
                 }]
@@ -729,7 +730,7 @@ fn cmd_init(repo: &Path, opts: InitOptions) -> Result<()> {
             println!("Installed Codex hook -> {}", hook_path.display());
 
             let hooks_path = codex_base.join("hooks.json");
-            let hook_command = codex_hook_command(&hook_path, codex_global);
+            let hook_command = codex_hook_command(&hook_path, codex_global)?;
             upsert_codex_hook(&hooks_path, &hook_command)?;
             println!("Updated Codex hooks -> {}", hooks_path.display());
 
@@ -1877,15 +1878,21 @@ fn cmd_estimate(
 /// On Windows, `PathBuf::to_str` returns backslash-separated paths. Bash (used
 /// by Claude Code to execute hooks) treats backslashes as escape sequences, so
 /// `C:\Users\foo` becomes `C:Usersfoo`. Forward slashes work on all platforms.
-fn path_to_hook_command(path: &std::path::Path) -> String {
-    path.to_str().unwrap().replace('\\', "/")
+fn path_to_hook_command(path: &Path) -> Result<String> {
+    let s = path.to_str().ok_or_else(|| {
+        anyhow::anyhow!(
+            "hook path is not valid UTF-8: {} — reinstall from a path without non-UTF-8 bytes",
+            path.display()
+        )
+    })?;
+    Ok(s.replace('\\', "/"))
 }
 
-fn codex_hook_command(path: &std::path::Path, global: bool) -> String {
+fn codex_hook_command(path: &Path, global: bool) -> Result<String> {
     if global {
-        format!("bash \"{}\"", path_to_hook_command(path))
+        Ok(format!("bash \"{}\"", path_to_hook_command(path)?))
     } else {
-        "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/pruner-context.sh\"".to_string()
+        Ok("bash \"$(git rev-parse --show-toplevel)/.codex/hooks/pruner-context.sh\"".to_string())
     }
 }
 
@@ -1985,7 +1992,7 @@ mod tests {
         // so that bash (used by Claude Code to run hooks) does not interpret them as
         // escape sequences (which would turn C:\Users\foo into C:Usersfoo).
         let hook_path = Path::new(r"C:\Users\testuser\.claude\hooks\pruner-context.sh");
-        let command = path_to_hook_command(hook_path);
+        let command = path_to_hook_command(hook_path).unwrap();
         assert!(
             !command.contains('\\'),
             "hook command path must use forward slashes for bash compatibility, got: {command}"
@@ -1993,10 +2000,25 @@ mod tests {
         assert_eq!(command, "C:/Users/testuser/.claude/hooks/pruner-context.sh");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_hook_command_non_utf8_path_returns_error() {
+        // Non-UTF-8 paths are rare but possible (user home with invalid bytes).
+        // The installer must surface a clear error instead of panicking.
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        let bad = Path::new(OsStr::from_bytes(b"/tmp/\xff/hooks/pruner.sh"));
+        let err = path_to_hook_command(bad).unwrap_err();
+        assert!(
+            err.to_string().contains("UTF-8"),
+            "error message must mention UTF-8, got: {err}"
+        );
+    }
+
     #[test]
     fn test_codex_global_hook_command_uses_absolute_path() {
         let hook_path = Path::new(r"C:\Users\testuser\.codex\hooks\pruner-context.sh");
-        let command = codex_hook_command(hook_path, true);
+        let command = codex_hook_command(hook_path, true).unwrap();
         assert_eq!(
             command,
             "bash \"C:/Users/testuser/.codex/hooks/pruner-context.sh\""
@@ -2006,7 +2028,7 @@ mod tests {
     #[test]
     fn test_codex_project_hook_command_uses_git_root() {
         let hook_path = Path::new("/tmp/repo/.codex/hooks/pruner-context.sh");
-        let command = codex_hook_command(hook_path, false);
+        let command = codex_hook_command(hook_path, false).unwrap();
         assert_eq!(
             command,
             "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/pruner-context.sh\""


### PR DESCRIPTION
## Summary
- `path_to_hook_command` previously called `to_str().unwrap()` on the hook path, which panics the installer if the path contains non-UTF-8 bytes (rare on macOS, possible on Windows).
- Returns a proper `anyhow::Result` with a clear `"hook path is not valid UTF-8"` message instead, and propagates the error through `codex_hook_command` and both call sites in `cmd_init`.
- Addresses item # 26 from TODO.md.

## Test plan
- [x] New `test_hook_command_non_utf8_path_returns_error` unit test (Unix-only, constructs a non-UTF-8 `Path` via `OsStr::from_bytes`) asserts an error is returned, not a panic.
- [x] Existing hook-command tests updated to `.unwrap()` the new `Result` return type.
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test --bin pruner --test integration` all clean (354 unit + 95 integration tests pass).