### PR TITLE
ci: bump action-gh-release to v3 (Node 24 runtime)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           path: artifacts
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |


### PR DESCRIPTION
## What

Bump `softprops/action-gh-release` from `@v2` to `@v3` in the release workflow.

## Why

The v0.2.9 release run logged a deprecation annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: softprops/action-gh-release@v2.

`v3.0.0` is a **runtime-only** migration moving the action from the Node 20 to the Node 24 Actions runtime, with no functional changes. Bumping to `@v3` clears the warning. GitHub-hosted runners already support the Node 24 runtime.

## Notes

This only touches `.github/workflows/release.yml` (the `Create release` step). The change takes effect on the next `v*` tag push.